### PR TITLE
LP-INFRA-003: aislar el trabajo de agentes por rama

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Spec e issue
+
+- **Spec:** `LP-TIPO-000` — enlace:
+- **Issue:** Closes #
+
+## Resultado
+
+Describe el comportamiento final que revisará la persona responsable.
+
+## Validación
+
+- [ ] Todos los `AC-XX` de la spec están comprobados o el estado permanece `IMPLEMENTED`.
+- [ ] `npm run specs:check` termina correctamente.
+- [ ] Las pruebas adecuadas al cambio terminan correctamente.
+- [ ] La spec, `SPEC_REGISTRY.md` y las etiquetas de la issue muestran el mismo estado.
+
+## Contexto transversal
+
+- [ ] He actualizado `PROJECT_CONTEXT.md` porque cambia funciones, servicios, variables, rutas, estados o limitaciones transversales.
+- [ ] No necesita actualización. Motivo:
+
+Marca solo una opción de contexto y elimina la otra antes de solicitar integración.

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -22,3 +22,6 @@ jobs:
         env:
           SPEC_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
         run: npm run specs:check -- --changed-from "$SPEC_BASE_SHA"
+      - name: Validate task branch
+        if: github.event_name == 'pull_request'
+        run: npm run specs:check -- --branch-name "${{ github.head_ref }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,29 @@ Este archivo es el punto de entrada para cualquier IA que trabaje en el reposito
 5. Clasifica la petición como `FEATURE`, `FIX`, `INFRA`, `SECURITY`, `TECH-DEBT`, `EXPERIMENT`, `OPS` o `DOC`.
 6. Comprueba el estado, el alcance, las dependencias y los criterios de aceptación. No mezcles objetivos distintos en una sola especificación.
 
+## Aislamiento obligatorio por rama y worktree
+
+No implementes una solicitud directamente en `main` o `master`. No cambies de rama ni uses `git stash` en una copia de trabajo que tenga cambios ajenos. Cada spec activa necesita una rama y un worktree exclusivos antes de modificar archivos.
+
+1. Comprueba `git status`, `git worktree list` y las ramas existentes sin alterar cambios.
+2. Actualiza referencias con `git fetch origin`.
+3. Desde el repositorio principal, crea un worktree nuevo basado en `origin/main`: `git worktree add <directorio-aislado> -b <rama> origin/main`.
+4. Usa la rama `<agente>/<id-de-spec-en-minúsculas>-<slug>`, por ejemplo `gemini/lp-feat-004-seo` o `codex/lp-fix-002-login`.
+5. Trabaja, valida, confirma y publica únicamente los archivos de esa spec. No incluyas cambios encontrados en otro worktree.
+6. Abre una pull request hacia `main`. La descripción debe enlazar spec e issue, incluir la evidencia y declarar si `PROJECT_CONTEXT.md` necesitó actualización.
+
+Si la rama o el worktree ya existen, reutilízalos tras comprobar que corresponden a la misma spec. Si otro agente los está usando, no escribas en ellos: coordina el relevo o crea un worktree distinto sobre la misma rama solo después de que deje de estar activa.
+
+### Estado de la issue durante el ciclo
+
+- **Inicio:** deja la issue abierta, aplica `status:in-progress` y anota el nombre de la rama.
+- **Pull request preparada:** enlaza la PR, actualiza la spec con evidencia y usa `status:implemented` mientras falte alguna comprobación.
+- **Lista para integrar:** marca `VERIFIED` y `status:verified` únicamente con todos los `AC-XX` comprobados y la PR preparada para `main`.
+- **Integración:** usa `Closes #<issue>` en la PR para que GitHub cierre la issue al fusionarla. Si se cancela, documenta el motivo en ficha e issue y ciérrala como no planificada.
+- **Bloqueo:** mantén la issue abierta con `status:blocked` y documenta la dependencia concreta.
+
+Antes de terminar, verifica que ficha, registro, issue, rama y PR muestran el mismo estado. Una implementación sin commit, una rama sin publicar o una issue desactualizada no es una entrega completa.
+
 ## Cómo interpretar una petición
 
 La clasificación de la ficha y la clase de requisito son dos conceptos diferentes:

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -289,3 +289,9 @@ La gobernanza documental se comprueba localmente con `npm run specs:check` y en 
 Cada solicitud que requiere una spec tiene una GitHub Issue en `github.com/jorgeluquerubia/lapela/issues`. La ficha contiene el enlace en `github_issue`. Se usan etiquetas `type:*`, `priority:*` y `status:*`; una issue permanece abierta mientras haya trabajo y se cierra cuando la ficha pasa a `VERIFIED` o `CANCELLED`.
 
 La spec continúa siendo la fuente de verdad para requisitos, criterios de aceptación, decisiones y validación. GitHub Issues aporta la vista operativa y no debe contener una copia independiente de toda la ficha.
+
+## 17. Ramas y concurrencia entre agentes
+
+`main` contiene únicamente trabajo integrado. Cada spec se implementa en una rama `<agente>/<id-de-spec-en-minúsculas>-<slug>` creada desde `origin/main`, por ejemplo `codex/lp-infra-003-agent-branches`. Cuando hay varios agentes, cada uno usa además un Git worktree diferente; compartir directorio aunque se usen ramas distintas no se considera aislamiento.
+
+La entrega se integra mediante pull request. La PR enlaza la spec y la issue, contiene la evidencia de validación e indica si cambió este contexto. El workflow de gobernanza valida el nombre de la rama y que su ID corresponda a una spec registrada. La issue permanece abierta hasta la integración en `main`.

--- a/SPEC_REGISTRY.md
+++ b/SPEC_REGISTRY.md
@@ -54,7 +54,7 @@ Prioridades: `P0` bloquea una operación esencial o implica un riesgo grave; `P1
 | `LP-INFRA-001` | `INFRA` | Controles automáticos para specs y acceso de agentes | `VERIFIED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-INFRA-001-spec-guardrails.md) |
 | `LP-INFRA-002` | `INFRA` | Trazabilidad de specs mediante GitHub Issues | `VERIFIED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-INFRA-002-github-issues.md) |
 | `LP-FEAT-004` | `FEATURE` | Optimización SEO y rutas semánticas | `IN_PROGRESS` | `P2` | 2026-09-06 | [Abrir ficha](specs/LP-FEAT-004-seo-semantic-urls.md) |
-| `LP-INFRA-003` | `INFRA` | Trabajo aislado por rama para agentes concurrentes | `IMPLEMENTED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-INFRA-003-agent-branches.md) |
+| `LP-INFRA-003` | `INFRA` | Trabajo aislado por rama para agentes concurrentes | `VERIFIED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-INFRA-003-agent-branches.md) |
 
 ## Flujo para una solicitud nueva
 

--- a/SPEC_REGISTRY.md
+++ b/SPEC_REGISTRY.md
@@ -54,6 +54,7 @@ Prioridades: `P0` bloquea una operación esencial o implica un riesgo grave; `P1
 | `LP-INFRA-001` | `INFRA` | Controles automáticos para specs y acceso de agentes | `VERIFIED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-INFRA-001-spec-guardrails.md) |
 | `LP-INFRA-002` | `INFRA` | Trazabilidad de specs mediante GitHub Issues | `VERIFIED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-INFRA-002-github-issues.md) |
 | `LP-FEAT-004` | `FEATURE` | Optimización SEO y rutas semánticas | `IN_PROGRESS` | `P2` | 2026-09-06 | [Abrir ficha](specs/LP-FEAT-004-seo-semantic-urls.md) |
+| `LP-INFRA-003` | `INFRA` | Trabajo aislado por rama para agentes concurrentes | `IMPLEMENTED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-INFRA-003-agent-branches.md) |
 
 ## Flujo para una solicitud nueva
 

--- a/specs/LP-INFRA-003-agent-branches.md
+++ b/specs/LP-INFRA-003-agent-branches.md
@@ -1,7 +1,7 @@
 ---
 id: LP-INFRA-003
 type: INFRA
-status: IMPLEMENTED
+status: VERIFIED
 priority: P1
 requested_at: 2026-09-06
 requested_by: usuario
@@ -72,10 +72,10 @@ Cada solicitud se desarrolla en una rama y un worktree propios. El agente enlaza
 - [x] `AC-01` `AGENTS.md` contiene listas obligatorias de inicio, trabajo y cierre para ramas, worktrees e issues.
 - [x] `AC-02` Las instrucciones prohíben trabajar directamente en `main` y compartir un worktree entre agentes concurrentes.
 - [x] `AC-03` Existe una plantilla de pull request que exige ID, spec, issue, validación y actualización de contexto.
-- [ ] `AC-04` GitHub Actions valida la rama `<agente>/<id>-<slug>` en cada pull request.
+- [x] `AC-04` GitHub Actions valida la rama `<agente>/<id>-<slug>` en cada pull request.
 - [x] `AC-05` La propia mejora se desarrolla en `codex/lp-infra-003-agent-branches` dentro de un worktree aislado.
 - [x] `AC-06` `PROJECT_CONTEXT.md` describe el flujo operativo vigente.
-- [ ] `AC-07` La feature SEO se conserva sin mezclar sus archivos con esta rama y su issue queda sincronizada tras validarla.
+- [x] `AC-07` La feature SEO se conserva sin mezclar sus archivos con esta rama y su issue queda sincronizada tras validarla.
 
 ## 7. Experiencia y estados
 
@@ -96,8 +96,8 @@ Cada solicitud se desarrolla en una rama y un worktree propios. El agente enlaza
 | Aislamiento | La rama actual usa otro worktree y no incluye el diff SEO | `git worktree list`, rama y diff | 2026-09-06 |
 | Documentación | Specs y enlaces internos son válidos | 10 fichas y 21 documentos válidos | 2026-09-06 |
 | Rama inválida | El validador rechaza un nombre fuera de convención | `feature/seo` produce el error esperado | 2026-09-06 |
-| Pull request | CI ejecuta los controles y la PR contiene trazabilidad | Enlace a PR | pendiente |
-| SEO | Build y criterios de `LP-FEAT-004` comprobados antes de cerrar su issue | Evidencia en su spec | pendiente |
+| Pull request | CI ejecuta los controles y la PR contiene trazabilidad | PR `#11`: gobernanza y Vercel correctos | 2026-09-06 |
+| SEO | Build y criterios de `LP-FEAT-004` comprobados antes de cerrar su issue | 16 pruebas y build correctos; issue `#9` permanece abierta como `IMPLEMENTED` | 2026-09-06 |
 
 ## 10. Decisiones, riesgos y preguntas abiertas
 
@@ -111,7 +111,7 @@ Cada solicitud se desarrolla en una rama y un worktree propios. El agente enlaza
 - **Rama:** `codex/lp-infra-003-agent-branches`.
 - **Worktree:** `/Users/jorgeluque/lapela-next-worktrees/lp-infra-003`.
 - **Issue:** `https://github.com/jorgeluquerubia/lapela/issues/10`.
-- **Pull request:** pendiente.
+- **Pull request:** `https://github.com/jorgeluquerubia/lapela/pull/11`.
 - **Archivos:** `AGENTS.md`, `PROJECT_CONTEXT.md`, `.github/pull_request_template.md` y workflow de gobernanza.
 
 ## 12. Historial
@@ -120,3 +120,4 @@ Cada solicitud se desarrolla en una rama y un worktree propios. El agente enlaza
 |---|---|---|---|
 | 2026-09-06 | `IN_PROGRESS` | Flujo concurrente registrado e iniciado en worktree aislado | Codex |
 | 2026-09-06 | `IMPLEMENTED` | Instrucciones, plantilla de PR y validación de rama incorporadas | Codex |
+| 2026-09-06 | `VERIFIED` | Rama real aceptada en CI y trabajo SEO separado y sincronizado | Codex |

--- a/specs/LP-INFRA-003-agent-branches.md
+++ b/specs/LP-INFRA-003-agent-branches.md
@@ -1,0 +1,122 @@
+---
+id: LP-INFRA-003
+type: INFRA
+status: IMPLEMENTED
+priority: P1
+requested_at: 2026-09-06
+requested_by: usuario
+source: conversación
+owner: producto
+github_issue: https://github.com/jorgeluquerubia/lapela/issues/10
+related_specs: [LP-INFRA-001, LP-INFRA-002]
+dependencies: [Git, GitHub]
+cross_cutting_concerns: [OPS, DOC]
+---
+
+# LP-INFRA-003 · Trabajo aislado por rama para agentes concurrentes
+
+## 1. Solicitud original
+
+> Dar instrucciones automáticas a los agentes para actualizar GitHub Issues al terminar y empezar a trabajar en ramas, porque varios agentes pueden modificar el proyecto en paralelo.
+
+## 2. Contexto y problema
+
+Un agente de Gemini completó `LP-FEAT-004` en la misma copia de trabajo que otros cambios. Aunque la regla de issues ya existía cuando terminó, había empezado antes de publicarse y no actualizó la issue. Compartir rama y directorio permite mezclar archivos, sobrescribir cambios o atribuir una implementación a la tarea equivocada.
+
+## 3. Resultado esperado
+
+Cada solicitud se desarrolla en una rama y un worktree propios. El agente enlaza rama y pull request en la issue, mantiene sus estados sincronizados y no toca una copia de trabajo que otro agente esté usando.
+
+## 4. Alcance
+
+### Incluido
+
+- Flujo obligatorio desde `origin/main` hacia rama, worktree, commit, push y pull request.
+- Convención de nombres con agente e ID de spec.
+- Prohibición de implementar directamente en `main` o compartir un worktree entre tareas concurrentes.
+- Lista de comprobación de inicio y cierre en `AGENTS.md`.
+- Plantilla de pull request con trazabilidad de spec e issue.
+- Validación automática del nombre de rama en pull requests.
+- Corrección de la issue de `LP-FEAT-004` al verificar su entrega.
+
+### Excluido
+
+- Exigir aprobación de otra persona para cada merge.
+- Elegir una herramienta externa de planificación.
+- Reescribir o descartar cambios que ya estén sin commit en la copia principal.
+
+## 5. Requisitos y reglas de negocio
+
+### Requisitos funcionales
+
+- `RF-01`: un agente debe crear una rama y un worktree exclusivos antes de modificar una tarea.
+- `RF-02`: la rama debe identificar agente y spec mediante `<agente>/<id-en-minúsculas>-<slug>`.
+- `RF-03`: la issue debe reflejar los estados de inicio, pull request y finalización.
+- `RF-04`: toda pull request debe enlazar la spec y cerrar o relacionar su issue.
+- `RF-05`: CI debe rechazar una pull request cuya rama no siga la convención.
+
+### Requisitos no funcionales
+
+- `RNF-01`: el flujo debe permitir varios agentes simultáneos sin compartir archivos modificables.
+- `RNF-02`: ninguna instrucción debe exigir borrar o guardar temporalmente cambios ajenos.
+
+### Reglas de negocio
+
+- `RN-01`: `main` representa trabajo integrado y no se usa como rama de implementación.
+- `RN-02`: una rama contiene una spec principal; los fixes descubiertos con alcance propio usan otra spec y, si pueden separarse, otra rama.
+- `RN-03`: el prefijo identifica al agente (`codex`, `gemini`, `claude` u otro nombre estable).
+- `RN-04`: `VERIFIED` requiere evidencia, criterios marcados, issue actualizada y una pull request preparada; la issue solo se cierra al integrar en `main`.
+
+## 6. Criterios de aceptación
+
+- [x] `AC-01` `AGENTS.md` contiene listas obligatorias de inicio, trabajo y cierre para ramas, worktrees e issues.
+- [x] `AC-02` Las instrucciones prohíben trabajar directamente en `main` y compartir un worktree entre agentes concurrentes.
+- [x] `AC-03` Existe una plantilla de pull request que exige ID, spec, issue, validación y actualización de contexto.
+- [ ] `AC-04` GitHub Actions valida la rama `<agente>/<id>-<slug>` en cada pull request.
+- [x] `AC-05` La propia mejora se desarrolla en `codex/lp-infra-003-agent-branches` dentro de un worktree aislado.
+- [x] `AC-06` `PROJECT_CONTEXT.md` describe el flujo operativo vigente.
+- [ ] `AC-07` La feature SEO se conserva sin mezclar sus archivos con esta rama y su issue queda sincronizada tras validarla.
+
+## 7. Experiencia y estados
+
+- Al comenzar, la issue cambia a `status:in-progress` y recibe el nombre de la rama.
+- Al abrir la pull request, se enlazan issue y spec y se anotan las comprobaciones.
+- Después de integrar y verificar, la spec pasa a `VERIFIED`, la etiqueta cambia y la issue se cierra.
+
+## 8. Datos, API, seguridad y operación
+
+- No cambia el producto ni sus datos.
+- Las ramas se crean desde `origin/main` actualizado.
+- Los worktrees viven fuera del directorio compartido principal y no contienen secretos versionados.
+
+## 9. Plan de validación
+
+| Comprobación | Resultado esperado | Evidencia | Fecha |
+|---|---|---|---|
+| Aislamiento | La rama actual usa otro worktree y no incluye el diff SEO | `git worktree list`, rama y diff | 2026-09-06 |
+| Documentación | Specs y enlaces internos son válidos | 10 fichas y 21 documentos válidos | 2026-09-06 |
+| Rama inválida | El validador rechaza un nombre fuera de convención | `feature/seo` produce el error esperado | 2026-09-06 |
+| Pull request | CI ejecuta los controles y la PR contiene trazabilidad | Enlace a PR | pendiente |
+| SEO | Build y criterios de `LP-FEAT-004` comprobados antes de cerrar su issue | Evidencia en su spec | pendiente |
+
+## 10. Decisiones, riesgos y preguntas abiertas
+
+- **Decisión:** usar worktrees además de ramas; dos ramas en el mismo directorio no evitan interferencias simultáneas.
+- **Decisión:** permitir distintos prefijos de agente con un patrón común.
+- **Riesgo:** los cambios anteriores sin commit siguen juntos en la copia principal y deben separarse con cuidado al integrar SEO.
+- **Preguntas abiertas:** ninguna.
+
+## 11. Implementación y trazabilidad
+
+- **Rama:** `codex/lp-infra-003-agent-branches`.
+- **Worktree:** `/Users/jorgeluque/lapela-next-worktrees/lp-infra-003`.
+- **Issue:** `https://github.com/jorgeluquerubia/lapela/issues/10`.
+- **Pull request:** pendiente.
+- **Archivos:** `AGENTS.md`, `PROJECT_CONTEXT.md`, `.github/pull_request_template.md` y workflow de gobernanza.
+
+## 12. Historial
+
+| Fecha | Estado | Cambio | Autor/agente |
+|---|---|---|---|
+| 2026-09-06 | `IN_PROGRESS` | Flujo concurrente registrado e iniciado en worktree aislado | Codex |
+| 2026-09-06 | `IMPLEMENTED` | Instrucciones, plantilla de PR y validación de rama incorporadas | Codex |

--- a/tools/validate-specs.mjs
+++ b/tools/validate-specs.mjs
@@ -273,6 +273,22 @@ if (changedFromIndex !== -1) {
   }
 }
 
+const branchNameIndex = process.argv.indexOf('--branch-name');
+if (branchNameIndex !== -1) {
+  const branchName = process.argv[branchNameIndex + 1];
+  const branchMatch = branchName?.match(
+    /^[a-z0-9][a-z0-9-]*\/(lp-(feat|fix|infra|sec|debt|exp|ops|doc)-\d{3})-[a-z0-9][a-z0-9-]*$/,
+  );
+  if (!branchMatch) {
+    fail(`La rama '${branchName ?? ''}' debe usar <agente>/<id-de-spec-en-minúsculas>-<slug>.`);
+  } else {
+    const branchSpecId = branchMatch[1].toUpperCase();
+    if (!specs.has(branchSpecId)) {
+      fail(`La rama '${branchName}' referencia '${branchSpecId}', que no existe en el registro.`);
+    }
+  }
+}
+
 if (errors.length > 0) {
   console.error(`Validación de specs fallida (${errors.length} error${errors.length === 1 ? '' : 'es'}):`);
   for (const error of errors) console.error(`- ${error}`);


### PR DESCRIPTION
## Spec e issue

- **Spec:** [LP-INFRA-003](https://github.com/jorgeluquerubia/lapela/blob/codex/lp-infra-003-agent-branches/specs/LP-INFRA-003-agent-branches.md)
- **Issue:** Closes #10

## Resultado

Obliga a cada agente a trabajar en una rama y un worktree exclusivos por spec, sincronizar la GitHub Issue durante todo el ciclo y entregar mediante pull request. El workflow de specs valida que el nombre de la rama contenga un ID registrado.

## Validación

- [x] `npm run specs:check` termina correctamente con 10 fichas y 21 documentos.
- [x] La rama válida `codex/lp-infra-003-agent-branches` es aceptada.
- [x] La rama inválida `feature/seo` es rechazada.
- [x] La mejora se creó en un worktree aislado y no contiene los cambios SEO del directorio principal.

## Contexto transversal

- [x] `PROJECT_CONTEXT.md` documenta el flujo de ramas, worktrees, PRs e issues.
