### PR TITLE
LP-FEAT-005: sección pública de preguntas y respuestas en producto (#13)

### DIFF
--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -86,6 +86,7 @@ La propuesta combina la sencillez de uso de un marketplace móvil con dos mecani
 
 - Chat privado solo para comprador y vendedor de un pedido en estado pagado o posterior.
 - Límite de veinte mensajes por minuto y usuario.
+- Preguntas y respuestas públicas en la ficha de producto con paginación de 10 elementos, aviso anti-regateo, bloqueo de datos de contacto y notificaciones de preguntas pendientes para el vendedor.
 - Seguimiento de compras, ventas, pujas y anuncios en `Mi actividad`.
 - Denuncia de anuncios para revisión.
 
@@ -94,7 +95,6 @@ La propuesta combina la sencillez de uso de un marketplace móvil con dos mecani
 - Cobros reales y transferencias a vendedores.
 - SMTP de producción y garantías de entrega de correo.
 - Seguro de compra o depósito en garantía.
-- Sistema público de preguntas y respuestas previo a la compra.
 - Regateo, contraofertas o chat libre entre usuarios.
 - Reputación, valoraciones y perfiles públicos completos.
 - Panel operativo de moderación, disputas y reembolsos.
@@ -195,6 +195,7 @@ Las claves secretas no deben usar el prefijo `NEXT_PUBLIC_`, aparecer en specs, 
 - `lp_bids`: historial de pujas.
 - `lp_orders`: comprador, vendedor, importe, pago, dirección, seguimiento y estado.
 - `lp_messages`: conversación ligada al pedido.
+- `lp_questions`: preguntas y respuestas públicas del producto y estado de notificación.
 - `lp_accounts`: cuenta Stripe Connect del vendedor.
 - `lp_reports`: denuncias de anuncios o pedidos.
 - `lp_payment_events`: idempotencia de eventos Stripe.
@@ -209,6 +210,8 @@ Las claves secretas no deben usar el prefijo `NEXT_PUBLIC_`, aparecer en specs, 
 - `lp_transition`: controla envío y recepción según actor y estado.
 - `lp_release`: cancela reservas caducadas y libera el anuncio.
 - `lp_send_message`: autoriza chat solo entre las partes después del pago.
+- `lp_ask_question`: valida y registra una pregunta pública impidiendo la auto-pregunta del vendedor.
+- `lp_answer_question`: autoriza únicamente al vendedor para publicar la respuesta oficial.
 
 Las tablas `lp_*` tienen RLS activado, pero `anon` y `authenticated` no tienen acceso directo. Las operaciones pasan por el backend con `service_role`, que valida al usuario mediante Supabase Auth. El middleware devuelve HTTP 410 para mutaciones legacy. `next.config.mjs` añade cabeceras de seguridad contra sniffing, framing y permisos de cámara, micrófono y geolocalización.
 
@@ -220,11 +223,14 @@ El bucket `product-images` es público porque contiene fotografías de anuncios.
 |---|---|---|
 | `GET /api/products` | Público | Catálogo filtrado del entorno activo |
 | `GET /api/market/listing/:id` | Público | Detalle seguro del anuncio |
-| `GET /api/market/activity` | Autenticado | Compras, ventas, pujas y anuncios propios |
+| `GET /api/market/questions/:id` | Público | Preguntas y respuestas paginadas (10 por página) |
+| `GET /api/market/activity` | Autenticado | Compras, ventas, pujas, anuncios y preguntas pendientes |
 | `GET /api/market/order/:id` | Partes del pedido | Pedido, mensajes y datos autorizados |
 | `POST /api/market/upload` | Autenticado | Subir una fotografía validada |
 | `POST /api/market/publish` | Autenticado | Crear un anuncio |
 | `POST /api/market/bid/:id` | Autenticado | Registrar una puja |
+| `POST /api/market/question/:id` | Comprador potencial | Formular pregunta pública sin regateos ni datos privados |
+| `POST /api/market/answer/:id` | Vendedor del artículo | Responder públicamente a una pregunta |
 | `POST /api/market/checkout/:id` | Comprador | Reservar o continuar un pago |
 | `POST /api/market/simulate-payment/:id` | Comprador, sandbox | Confirmar pago simulado |
 | `POST /api/market/message/:id` | Partes, pedido pagado | Enviar mensaje sobre la entrega |
@@ -234,6 +240,7 @@ El bucket `product-images` es público porque contiene fotografías de anuncios.
 | `POST /api/market/report/:id` | Autenticado | Denunciar un anuncio |
 | `POST /api/market/onboard` | Vendedor, modo real | Iniciar onboarding de Stripe Connect |
 | `POST /api/stripe/webhook` | Stripe firmado | Confirmar pagos reales de forma idempotente |
+
 
 Las rutas antiguas bajo `/api/bids`, `/api/messages`, `/api/orders`, `/api/questions`, mutaciones de `/api/products` y equivalentes se conservan para referencia o compatibilidad controlada, pero las mutaciones responden HTTP 410. Su código archivado está en `archive/legacy-api`.
 

--- a/SPEC_REGISTRY.md
+++ b/SPEC_REGISTRY.md
@@ -57,6 +57,7 @@ Prioridades: `P0` bloquea una operación esencial o implica un riesgo grave; `P1
 | `LP-INFRA-003` | `INFRA` | Trabajo aislado por rama para agentes concurrentes | `VERIFIED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-INFRA-003-agent-branches.md) |
 | `LP-INFRA-004` | `INFRA` | Worktrees dentro del workspace autorizado | `VERIFIED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-INFRA-004-worktree-location.md) |
 | `LP-FIX-002` | `FIX` | Playwright funcional en pull requests | `IMPLEMENTED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-FIX-002-playwright-ci.md) |
+| `LP-FEAT-005` | `FEATURE` | Preguntas y respuestas públicas en producto | `IMPLEMENTED` | `P2` | 2026-09-06 | [Abrir ficha](specs/LP-FEAT-005-preguntas-respuestas-producto.md) |
 
 ## Flujo para una solicitud nueva
 

--- a/SPEC_REGISTRY.md
+++ b/SPEC_REGISTRY.md
@@ -56,8 +56,8 @@ Prioridades: `P0` bloquea una operación esencial o implica un riesgo grave; `P1
 | `LP-FEAT-004` | `FEATURE` | Optimización SEO y rutas semánticas | `VERIFIED` | `P2` | 2026-09-06 | [Abrir ficha](specs/LP-FEAT-004-seo-semantic-urls.md) |
 | `LP-INFRA-003` | `INFRA` | Trabajo aislado por rama para agentes concurrentes | `VERIFIED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-INFRA-003-agent-branches.md) |
 | `LP-INFRA-004` | `INFRA` | Worktrees dentro del workspace autorizado | `VERIFIED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-INFRA-004-worktree-location.md) |
-| `LP-FIX-002` | `FIX` | Playwright funcional en pull requests | `IMPLEMENTED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-FIX-002-playwright-ci.md) |
-| `LP-FEAT-005` | `FEATURE` | Preguntas y respuestas públicas en producto | `IMPLEMENTED` | `P2` | 2026-09-06 | [Abrir ficha](specs/LP-FEAT-005-preguntas-respuestas-producto.md) |
+| `LP-FIX-002` | `FIX` | Playwright funcional en pull requests | `VERIFIED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-FIX-002-playwright-ci.md) |
+| `LP-FEAT-005` | `FEATURE` | Preguntas y respuestas públicas en producto | `VERIFIED` | `P2` | 2026-09-06 | [Abrir ficha](specs/LP-FEAT-005-preguntas-respuestas-producto.md) |
 
 ## Flujo para una solicitud nueva
 

--- a/specs/LP-FEAT-005-preguntas-respuestas-producto.md
+++ b/specs/LP-FEAT-005-preguntas-respuestas-producto.md
@@ -1,7 +1,7 @@
 ---
 id: LP-FEAT-005
 type: FEATURE
-status: IMPLEMENTED
+status: VERIFIED
 priority: P2
 requested_at: 2026-09-06
 requested_by: usuario
@@ -114,6 +114,7 @@ Una sección pública de preguntas y respuestas en `/articulos/[slug]` donde:
 | Pruebas unitarias de dominio | `noBargaining` y `noContact` bloquean ofertas y datos externos | `rules-qa.test.ts` (4 pruebas unitarias pasadas) | 2026-09-06 |
 | Pruebas unitarias de componente | `ProductQA.test.tsx` valida render, avisos, envío y respuesta | `ProductQA.test.tsx` (5 pruebas unitarias pasadas) | 2026-09-06 |
 | Build del proyecto (`npm run build`) | Compilación limpia de TypeScript y Next.js | Next.js 15.5 compiló 25 páginas estáticas y rutas dinámicas | 2026-09-06 |
+| GitHub Actions en PR #14 | Gobernanza, Playwright y despliegue de preview correctos | `validate` en 11 s, `test` en 1 min 31 s y Vercel verde | 2026-09-06 |
 
 ## 10. Decisiones, riesgos y preguntas abiertas
 
@@ -152,3 +153,4 @@ Una sección pública de preguntas y respuestas en `/articulos/[slug]` donde:
 | 2026-09-06 | `IN_PROGRESS` | Creación de especificación e inicio de implementación | Gemini |
 | 2026-09-06 | `IMPLEMENTED` | Implementación local completada; validación de la PR pendiente | Gemini |
 | 2026-09-06 | `IMPLEMENTED` | Rebase sobre `main`, pruebas unitarias, build y specs superados; CI pendiente | Codex |
+| 2026-09-06 | `VERIFIED` | PR #14 sin conflictos y todos los controles remotos superados | Codex |

--- a/specs/LP-FEAT-005-preguntas-respuestas-producto.md
+++ b/specs/LP-FEAT-005-preguntas-respuestas-producto.md
@@ -1,0 +1,153 @@
+---
+id: LP-FEAT-005
+type: FEATURE
+status: IMPLEMENTED
+priority: P2
+requested_at: 2026-09-06
+requested_by: usuario
+source: conversación
+owner: producto
+github_issue: https://github.com/jorgeluquerubia/lapela/issues/13
+related_specs: [LP-FEAT-001]
+dependencies: []
+cross_cutting_concerns: []
+---
+
+# LP-FEAT-005 · Preguntas y respuestas públicas en producto
+
+## 1. Solicitud original
+
+> nueva funcionalidad: necesito que los compradores potenciales puedan hacer preguntas sobre un producto, esas preguntas se incluirán en la pagina de descripcion del propio producto de forma publica, así como las respuestas del vendedor a esas preguntas. Será una sección de preguntas y respuestas. Irán paginadas, maximo 10 preguntas por pagina. El comprador recibirá notificaciones de que tiene preguntas sin responder sobre su producto. En el formulario de hacer la pregunta, el comprador tiene que saber que las preguntas únicamente pueden ir relacionadas con la naturaleza, descripción, estado del producto, etc y nunca con regateos u otra información privada
+
+## 2. Contexto y problema
+
+- **Problema u oportunidad:** Los compradores potenciales necesitan resolver dudas previas a la compra sobre detalles, estado o características de un artículo sin violar el principio básico de La Pela: el precio no se regatea y no hay contacto privado antes del pago. La publicación transparente de preguntas y respuestas enriquece la ficha del artículo y evita preguntas repetidas.
+- **Personas afectadas:** Compradores potenciales con dudas sobre un producto y vendedores que necesitan atenderlas públicamente y ser notificados de preguntas pendientes.
+- **Impacto actual:** Hasta ahora, el sistema de preguntas previo al pago estaba deshabilitado en la reconstrucción v2 (`PROJECT_CONTEXT.md` sección 5).
+- **Evidencia disponible:** Solicitud explícita de usuario y registro histórico en `archive/legacy-api/questions`.
+
+## 3. Resultado esperado
+
+Una sección pública de preguntas y respuestas en `/articulos/[slug]` donde:
+- Compradores potenciales pueden enviar preguntas sobre el estado o naturaleza del producto.
+- En el formulario se explica de forma clara e ineludible que están prohibidos el regateo y los datos privados de contacto.
+- El vendedor puede responder a cada pregunta desde la propia ficha o su espacio de actividad.
+- Las preguntas se muestran paginadas (máximo 10 por página).
+- El vendedor recibe notificación / avisos visibles de preguntas sin responder sobre sus artículos.
+
+## 4. Alcance
+
+### Incluido
+
+- Tabla `lp_questions` en base de datos con relaciones seguras, integridad referencial y RLS.
+- Funciones RPC `lp_ask_question` y `lp_answer_question`.
+- Endpoints de backend bajo `/api/market/`:
+  - `GET /api/market/questions/:listingId?page=1`
+  - `POST /api/market/question/:listingId`
+  - `POST /api/market/answer/:questionId`
+- Validación de dominio `noContact` y `noBargaining` (bloqueo de regateos, peticiones de descuento o datos de contacto).
+- Paginación estricta de 10 preguntas por página en cliente y servidor.
+- Componente interactivo y accesible `ProductQA` integrado en la vista de detalle del artículo.
+- Notificaciones visibles para el vendedor: contador de preguntas pendientes en anuncio y en *Mi actividad*.
+- Notificación para el comprador cuando su pregunta haya sido respondida.
+
+### Excluido
+
+- Envío de correos SMTP externos (pendiente de configuración transversal de infraestructura).
+- Modificación o reapertura de chat privado previo al pago (el chat 1-a-1 sigue requiriendo pedido pagado).
+
+## 5. Requisitos y reglas de negocio
+
+### Requisitos funcionales
+
+- `RF-01`: Los usuarios autenticados pueden formular preguntas sobre un artículo disponible o reservado, siempre que no sean el vendedor del artículo.
+- `RF-02`: Las preguntas y sus correspondientes respuestas del vendedor se muestran públicamente en la ficha del artículo, ordenadas cronológicamente con paginación de 10 preguntas por página.
+- `RF-03`: El vendedor del artículo puede responder a cualquier pregunta formulada en sus anuncios. Solo el vendedor está autorizado a responder.
+- `RF-04`: El formulario para formular preguntas debe presentar advertencias visibles e impedir consultas orientadas a regateos de precio o que contengan datos de contacto externo.
+- `RF-05`: El vendedor debe visualizar notificaciones o avisos destacados con el número de preguntas pendientes de respuesta en sus anuncios y en *Mi actividad*.
+- `RF-06`: El comprador que realizó una pregunta puede ver en su interfaz el estado de su consulta y cuándo ha sido respondida por el vendedor.
+
+### Requisitos no funcionales
+
+- `RNF-01`: La paginación de preguntas en la API y en la interfaz debe estar limitada a un máximo de 10 elementos por solicitud.
+- `RNF-02`: La validación y persistencia de preguntas y respuestas debe protegerse frente a inyecciones, spam (límite de tasa de 10 preguntas por hora y usuario) y desbordamientos (longitud entre 5 y 1000 caracteres).
+- `RNF-03`: La interfaz debe ser completamente accesible (navegación por teclado, etiquetas ARIA, avisos de error comprensibles y legibles en móvil y escritorio).
+
+### Reglas de negocio
+
+- `RN-01`: El precio no se negocia. Toda pregunta que intente rebajar o negociar el precio será rechazada por validación tanto en cliente como en servidor.
+- `RN-02`: No se permite el intercambio de teléfonos, emails, redes sociales ni direcciones externas en preguntas ni respuestas.
+- `RN-03`: Un vendedor no puede formular preguntas sobre su propio anuncio.
+- `RN-04`: Solo el vendedor propietario del anuncio puede responder a las preguntas asociadas a dicho anuncio.
+
+## 6. Criterios de aceptación
+
+- [x] `AC-01` Dado un usuario autenticado que no es el vendedor, cuando envía una pregunta válida (sin regateos ni datos de contacto), entonces la pregunta se guarda y aparece listada en la sección pública de preguntas del producto.
+- [x] `AC-02` Dado un usuario que introduce una pregunta con intentos de regateo (ej. "te doy 20 euros", "rebaja", "haces descuento") o datos de contacto (ej. teléfono o email), cuando intenta enviarla, entonces el sistema la rechaza con un mensaje de error explicativo y no la publica.
+- [x] `AC-03` Dado un vendedor con anuncios que tienen preguntas sin responder, cuando accede a su anuncio o a *Mi actividad*, entonces visualiza una notificación o indicador claro de preguntas pendientes de respuesta.
+- [x] `AC-04` Dado el vendedor de un artículo, cuando envía una respuesta a una pregunta formulada en su producto, entonces la respuesta se publica asociada a la pregunta con la fecha de respuesta y el comprador puede verla.
+- [x] `AC-05` Dado un artículo con más de 10 preguntas, cuando se navega por la sección de preguntas, entonces la interfaz muestra exactamente 10 preguntas por página y permite cambiar de página.
+- [x] `AC-06` Dado un usuario anónimo (no autenticado), cuando visualiza la sección de preguntas, puede leer todas las preguntas y respuestas públicas, pero al intentar preguntar se le solicita iniciar sesión.
+
+## 7. Experiencia y estados
+
+- Estados normales: Lista paginada de preguntas con respuestas del vendedor; formulario de pregunta visible para compradores potenciales; botones de respuesta accesibles para el vendedor.
+- Estados de error o vacío: Estado vacío informativo ("Aún no hay preguntas sobre este artículo. Si tienes dudas sobre su estado o características, ¡sé el primero en preguntar!"); mensajes de error claros ante datos de contacto o regateos.
+- Mensajes y accesibilidad: Aviso normativo en caja destacada; feedback en regiones ARIA al enviar pregunta o respuesta.
+- Responsive o canales afectados: Ficha de producto en móvil y escritorio (`/articulos/[slug]`), panel de *Mi actividad* (`/my-products`).
+
+## 8. Datos, API, seguridad y operación
+
+- **Datos/modelo:** Tabla `lp_questions` con `id`, `listing_id`, `buyer_id`, `seller_id`, `question`, `answer`, `created_at`, `answered_at`, `seller_notified`, `buyer_notified`.
+- **API/integraciones:** Endpoints `/api/market/questions/:id`, `/api/market/question/:id`, `/api/market/answer/:id`.
+- **Autorización y privacidad:** RLS habilitado sin permisos directos para `anon` o `authenticated`; todas las mutaciones se controlan vía `service_role` tras verificar identidad con Supabase Auth. El vendedor solo puede responder a sus anuncios; el vendedor no puede preguntarse a sí mismo.
+- **Observabilidad y soporte:** Registro de errores estándar en backend con códigos HTTP semánticos (400, 401, 403, 404, 429).
+- **Métricas o señales de éxito:** Tasa de preguntas respondidas y reducción de cancelaciones por dudas de producto.
+- **Migración/rollback:** Migración SQL reversible en `supabase/migrations/202609060005_product_qa.sql`.
+
+## 9. Plan de validación
+
+| Comprobación | Resultado esperado | Evidencia | Fecha |
+|---|---|---|---|
+| `npm run specs:check` | Ficha registrada y gobernanza documental correcta | 11 fichas válidas y 22 documentos enlazados | 2026-09-06 |
+| Validación de invariantes SQL | Restricciones de auto-pregunta, propiedad de respuesta y RLS verificadas | `tests/database/marketplace.sql` ejecutado con éxito en PostgreSQL remoto | 2026-09-06 |
+| Pruebas unitarias de dominio | `noBargaining` y `noContact` bloquean ofertas y datos externos | `rules-qa.test.ts` (4 pruebas unitarias pasadas) | 2026-09-06 |
+| Pruebas unitarias de componente | `ProductQA.test.tsx` valida render, avisos, envío y respuesta | `ProductQA.test.tsx` (5 pruebas unitarias pasadas) | 2026-09-06 |
+| Build del proyecto (`npm run build`) | Compilación limpia de TypeScript y Next.js | Next.js 15.5 compiló 25 páginas estáticas y rutas dinámicas | 2026-09-06 |
+
+## 10. Decisiones, riesgos y preguntas abiertas
+
+- **Decisiones:**
+  - Se permite visibilidad pública inmediata de las preguntas realizadas indicando estado "Pendiente de respuesta del vendedor" para dar transparencia y evitar dudas duplicadas.
+  - Las notificaciones se presentan in-app en *Mi actividad* y en la ficha del anuncio mediante avisos destacados y contadores de preguntas pendientes.
+  - Se implementa validador `noBargaining` en `src/lib/rules.ts` para reforzar activamente el principio "El precio no se negocia".
+- **Riesgos y límites:**
+  - Posible spam: mitigado con límite de tasa de 10 preguntas por hora y validación de longitud (5 a 1000 caracteres).
+- **Preguntas abiertas:**
+  - Ninguna bloqueante tras la aprobación del plan de implementación.
+
+## 11. Implementación y trazabilidad
+
+- **Archivos o módulos:**
+  - `specs/LP-FEAT-005-preguntas-respuestas-producto.md`
+  - `SPEC_REGISTRY.md`
+  - `PROJECT_CONTEXT.md`
+  - `supabase/migrations/202609060005_product_qa.sql`
+  - `src/lib/rules.ts`
+  - `src/lib/__tests__/rules-qa.test.ts`
+  - `src/controllers/marketplace.ts`
+  - `src/components/ProductQA.tsx`
+  - `src/components/__tests__/ProductQA.test.tsx`
+  - `src/components/ProductDetailInteractive.tsx`
+  - `src/app/my-products/page.tsx`
+  - `tests/database/marketplace.sql`
+- **Migraciones/configuración:** `202609060005_product_qa.sql`
+- **Commit o despliegue:** Pendiente de commit y PR
+- **Notas de implementación:** Ejecución en rama aislada `gemini/lp-feat-005-product-qa`.
+
+## 12. Historial
+
+| Fecha | Estado | Cambio | Autor/agente |
+|---|---|---|---|
+| 2026-09-06 | `IN_PROGRESS` | Creación de especificación e inicio de implementación | Gemini |
+| 2026-09-06 | `IMPLEMENTED` | Implementación local completada; validación de la PR pendiente | Gemini |

--- a/specs/LP-FEAT-005-preguntas-respuestas-producto.md
+++ b/specs/LP-FEAT-005-preguntas-respuestas-producto.md
@@ -109,7 +109,7 @@ Una sección pública de preguntas y respuestas en `/articulos/[slug]` donde:
 
 | Comprobación | Resultado esperado | Evidencia | Fecha |
 |---|---|---|---|
-| `npm run specs:check` | Ficha registrada y gobernanza documental correcta | 11 fichas válidas y 22 documentos enlazados | 2026-09-06 |
+| `npm run specs:check` | Ficha registrada y gobernanza documental correcta | 13 fichas válidas y 24 documentos enlazados tras actualizar con `main` | 2026-09-06 |
 | Validación de invariantes SQL | Restricciones de auto-pregunta, propiedad de respuesta y RLS verificadas | `tests/database/marketplace.sql` ejecutado con éxito en PostgreSQL remoto | 2026-09-06 |
 | Pruebas unitarias de dominio | `noBargaining` y `noContact` bloquean ofertas y datos externos | `rules-qa.test.ts` (4 pruebas unitarias pasadas) | 2026-09-06 |
 | Pruebas unitarias de componente | `ProductQA.test.tsx` valida render, avisos, envío y respuesta | `ProductQA.test.tsx` (5 pruebas unitarias pasadas) | 2026-09-06 |
@@ -142,8 +142,8 @@ Una sección pública de preguntas y respuestas en `/articulos/[slug]` donde:
   - `src/app/my-products/page.tsx`
   - `tests/database/marketplace.sql`
 - **Migraciones/configuración:** `202609060005_product_qa.sql`
-- **Commit o despliegue:** Pendiente de commit y PR
-- **Notas de implementación:** Ejecución en rama aislada `gemini/lp-feat-005-product-qa`.
+- **Commit o despliegue:** commit original `2da151e`; PR [#14](https://github.com/jorgeluquerubia/lapela/pull/14).
+- **Notas de implementación:** Ejecución original en `gemini/lp-feat-005-product-qa`; actualización y resolución de conflictos preparada desde el worktree interno `.worktrees/lp-feat-005-pr14-repair`.
 
 ## 12. Historial
 
@@ -151,3 +151,4 @@ Una sección pública de preguntas y respuestas en `/articulos/[slug]` donde:
 |---|---|---|---|
 | 2026-09-06 | `IN_PROGRESS` | Creación de especificación e inicio de implementación | Gemini |
 | 2026-09-06 | `IMPLEMENTED` | Implementación local completada; validación de la PR pendiente | Gemini |
+| 2026-09-06 | `IMPLEMENTED` | Rebase sobre `main`, pruebas unitarias, build y specs superados; CI pendiente | Codex |

--- a/specs/LP-FIX-002-playwright-ci.md
+++ b/specs/LP-FIX-002-playwright-ci.md
@@ -1,7 +1,7 @@
 ---
 id: LP-FIX-002
 type: FIX
-status: IMPLEMENTED
+status: VERIFIED
 priority: P1
 requested_at: 2026-09-06
 requested_by: usuario
@@ -65,7 +65,7 @@ Las pull requests arrancan la aplicación con una configuración de prueba segur
 - [x] `AC-01` Dada una pull request, cuando se ejecuta el workflow, entonces Next.js arranca sin secretos de Supabase.
 - [x] `AC-02` Dado el catálogo de demostración, cuando Playwright abre el inicio y selecciona un artículo, entonces llega a su ruta semántica y muestra la descripción.
 - [x] `AC-03` El workflow completo de Playwright finaliza correctamente en GitHub Actions.
-- [ ] `AC-04` La PR #14 deja de fallar por esta causa y queda actualizada con `main`.
+- [x] `AC-04` La PR #14 deja de fallar por esta causa y queda actualizada con `main`.
 
 ## 7. Experiencia y estados
 
@@ -90,7 +90,7 @@ Las pull requests arrancan la aplicación con una configuración de prueba segur
 | Playwright local con entorno equivalente a CI | Recorrido verde | Chromium: 1 prueba superada en 4,2 s | 2026-09-06 |
 | `npm run specs:check` | Registro coherente | 12 fichas y 23 documentos válidos | 2026-09-06 |
 | GitHub Actions | Jobs `validate` y `test` verdes | PR #18: `validate` en 9 s y `test` en 1 min 40 s | 2026-09-06 |
-| PR #14 actualizada | Sin conflicto y Playwright verde | Pendiente | 2026-09-06 |
+| PR #14 actualizada | Sin conflicto y Playwright verde | `mergeable: MERGEABLE`; job `test` superado en 1 min 31 s | 2026-09-06 |
 
 ## 10. Decisiones, riesgos y preguntas abiertas
 
@@ -113,3 +113,4 @@ Las pull requests arrancan la aplicación con una configuración de prueba segur
 | 2026-09-06 | `IN_PROGRESS` | Configuración sintética y smoke test validados localmente | Codex |
 | 2026-09-06 | `IMPLEMENTED` | PR #18 abierta; validación de GitHub pendiente | Codex |
 | 2026-09-06 | `IMPLEMENTED` | CI completa verde; pendiente aplicar a PR #14 | Codex |
+| 2026-09-06 | `VERIFIED` | Corrección integrada en `main` y comprobada en PR #14 | Codex |

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,3 +7,23 @@
 .sandbox-banner{background:#f1f6de;color:#405315;text-align:center;padding:9px 20px;font-size:12px;letter-spacing:.035em;border-bottom:1px solid #dce5c6}
 .auth-actions{display:flex;flex-direction:column;align-items:center;gap:8px;margin:16px 0 8px}.auth-actions .button{width:100%}.auth-actions .text-link{margin-top:0}
 .forgot-link{align-self:flex-end;margin-top:-5px}
+
+.qa-section{margin-top:40px;border-top:1px solid var(--line);padding-top:30px}
+.qa-rule-banner{background:#f4f7f4;border:1px solid #d2ded5;border-radius:12px;padding:16px 20px;font-size:14px;margin-bottom:24px;color:var(--ink)}
+.qa-rule-banner strong{display:block;color:var(--green-dark);margin-bottom:6px;font-size:15px}
+.qa-rule-banner ul{margin:6px 0 0 18px;padding:0;color:#374942}
+.qa-rule-banner li{margin-bottom:3px}
+.qa-form{margin-bottom:32px;background:var(--surface);padding:22px;border-radius:14px;border:1px solid var(--line)}
+.qa-form textarea{min-height:95px;resize:vertical}
+.qa-card{border:1px solid var(--line);border-radius:12px;padding:18px 20px;margin-bottom:16px;background:white}
+.qa-question{display:flex;flex-direction:column;gap:6px}
+.qa-question p{margin:0;font-size:15px;color:var(--ink);font-weight:500}
+.qa-meta{font-size:13px;color:var(--muted)}
+.qa-answer{margin-top:14px;padding:14px 16px;background:#f4f8f2;border-left:3px solid var(--green);border-radius:0 8px 8px 0}
+.qa-answer p{margin:4px 0 0;font-size:15px;color:var(--ink)}
+.qa-answer-title{font-size:13px;font-weight:700;color:var(--green)}
+.qa-answer-pending{display:inline-block;margin-top:10px;font-size:13px;color:var(--muted);background:var(--surface);padding:4px 10px;border-radius:6px}
+.qa-answer-form{margin-top:14px;padding-top:14px;border-top:1px dashed var(--line)}
+.qa-pagination{display:flex;justify-content:space-between;align-items:center;margin-top:24px;gap:12px;flex-wrap:wrap}
+.qa-badge{display:inline-block;background:var(--green);color:white;font-size:11px;font-weight:700;padding:2px 7px;border-radius:10px;margin-left:6px;vertical-align:middle}
+.seller-alert-banner{background:#ebf5ef;border:1px solid #9dc7af;color:#0e4e36;padding:14px 18px;border-radius:12px;margin-bottom:24px;font-size:14px;display:flex;justify-content:space-between;align-items:center;gap:12px}

--- a/src/app/my-products/page.tsx
+++ b/src/app/my-products/page.tsx
@@ -1,11 +1,289 @@
 'use client';
-import {useEffect,useState} from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import {api} from '@/lib/api';
-import {money} from '@/lib/rules';
-import {useAuth} from '@/context/AuthContext';
-import {productSlug} from '@/lib/slugs';
-const labels:Record<string,string>={available:'A la venta',reserved:'Reservado',sold:'Vendido',expired:'Finalizado',withdrawn:'Retirado',pending_payment:'Pendiente de pago',paid:'Pagado',shipped:'Enviado',completed:'Completado',cancelled:'Cancelado',refunded:'Reembolsado',disputed:'En revisión'};
-export default function Activity(){const {user,loading}=useAuth();const [data,setData]=useState<any>(null);const [tab,setTab]=useState('purchases');const [error,setError]=useState('');const [withdraw,setWithdraw]=useState('');const [busy,setBusy]=useState(false);useEffect(()=>{if(user)api('activity').then(setData).catch(e=>setError(e.message))},[user]);async function remove(){setBusy(true);try{await api('withdraw/'+withdraw,{});setData(await api('activity'));setWithdraw('')}catch(e){setError((e as Error).message)}finally{setBusy(false)}}
-if(loading)return <p>Cargando…</p>;if(!user)return <div className="empty-state"><h1>Tus tratos, en un solo sitio.</h1><p>Entra para seguir tus compras, ventas y pujas.</p><Link href="/login" className="button primary">Entrar</Link></div>;const rows=!data?[]:tab==='listings'?data.listings:tab==='bids'?data.bids:data.orders.filter((o:any)=>tab==='purchases'?o.buyer_id===user.id:o.seller_id===user.id);
-return <><div className="catalog-head"><div><span className="eyebrow">TU ESPACIO</span><h1>Mi actividad</h1></div><Link className="button primary" href="/publish-ad">＋ Vender un artículo</Link></div><div className="mode-tabs activity-tabs">{[['purchases','Compras'],['sales','Ventas'],['bids','Mis pujas'],['listings','Mis anuncios']].map(([v,t])=><button key={v} className={tab===v?'active':''} onClick={()=>setTab(v)}>{t}</button>)}</div>{error&&<p className="error-message">{error}</p>}{!data&&!error?<p>Cargando actividad…</p>:!rows.length?<div className="empty-state"><h2>Todavía no hay actividad aquí</h2><p>Los artículos y pedidos aparecerán aquí cuando participes.</p><Link href="/" className="button">Explorar artículos</Link></div>:<div className="activity-list">{rows.map((r:any)=>{const l=r.listing||r;const slug=productSlug(r.listing_id||r.id,l.title);return <article key={r.id} className="activity-row"><img src={l.images[0]} alt={l.title}/><div><h3><Link href={tab==='listings'||tab==='bids'?'/articulos/'+slug:'/orders/'+r.id}>{l.title}</Link></h3><p className="muted">{labels[r.status||l.status]||r.status} · {new Date(r.created_at).toLocaleDateString('es-ES')}</p></div><strong>{money(r.amount_cents||r.price_cents)}</strong>{tab==='listings'?r.status==='available'&&!r.bid_count?<button className="button" onClick={()=>setWithdraw(r.id)}>Retirar</button>:null:tab!=='bids'?<Link className="button" href={'/orders/'+r.id}>Ver pedido →</Link>:<Link className="button" href={'/articulos/'+slug}>Ver subasta →</Link>}</article>})}</div>}{withdraw&&<div className="confirmation"><h2>¿Retirar este anuncio?</h2><p>Se conservará en tu historial y dejará de estar a la venta.</p><button className="button primary" disabled={busy} onClick={remove}>Retirar anuncio</button><button className="button" onClick={()=>setWithdraw('')}>Cancelar</button></div>}</>}
+import { api } from '@/lib/api';
+import { money } from '@/lib/rules';
+import { useAuth } from '@/context/AuthContext';
+import { productSlug } from '@/lib/slugs';
+
+const labels: Record<string, string> = {
+  available: 'A la venta',
+  reserved: 'Reservado',
+  sold: 'Vendido',
+  expired: 'Finalizado',
+  withdrawn: 'Retirado',
+  pending_payment: 'Pendiente de pago',
+  paid: 'Pagado',
+  shipped: 'Enviado',
+  completed: 'Completado',
+  cancelled: 'Cancelado',
+  refunded: 'Reembolsado',
+  disputed: 'En revisión',
+};
+
+export default function Activity() {
+  const { user, loading } = useAuth();
+  const [data, setData] = useState<any>(null);
+  const [tab, setTab] = useState('purchases');
+  const [error, setError] = useState('');
+  const [withdraw, setWithdraw] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (user) {
+      api('activity').then(setData).catch((e) => setError(e.message));
+    }
+  }, [user]);
+
+  async function remove() {
+    setBusy(true);
+    try {
+      await api('withdraw/' + withdraw, {});
+      setData(await api('activity'));
+      setWithdraw('');
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (loading) return <p>Cargando…</p>;
+
+  if (!user) {
+    return (
+      <div className="empty-state">
+        <h1>Tus tratos, en un solo sitio.</h1>
+        <p>Entra para seguir tus compras, ventas y pujas.</p>
+        <Link href="/login" className="button primary">
+          Entrar
+        </Link>
+      </div>
+    );
+  }
+
+  const rows = !data
+    ? []
+    : tab === 'listings'
+    ? data.listings
+    : tab === 'bids'
+    ? data.bids
+    : tab === 'questions'
+    ? []
+    : data.orders.filter((o: any) =>
+        tab === 'purchases' ? o.buyer_id === user.id : o.seller_id === user.id
+      );
+
+  const pendingQuestionsCount = data?.pendingQuestionsCount || 0;
+  const sellerQuestions = data?.sellerQuestions || [];
+  const buyerQuestions = data?.buyerQuestions || [];
+
+  return (
+    <>
+      <div className="catalog-head">
+        <div>
+          <span className="eyebrow">TU ESPACIO</span>
+          <h1>Mi actividad</h1>
+        </div>
+        <Link className="button primary" href="/publish-ad">
+          ＋ Vender un artículo
+        </Link>
+      </div>
+
+      {pendingQuestionsCount > 0 && (
+        <div className="seller-alert-banner" role="status">
+          <div>
+            <strong>
+              Tienes {pendingQuestionsCount} pregunta{pendingQuestionsCount === 1 ? '' : 's'} pendiente{pendingQuestionsCount === 1 ? '' : 's'} de responder.
+            </strong>
+            <p className="m-0 text-xs">
+              Responde a los compradores para resolver dudas sobre tus productos.
+            </p>
+          </div>
+          <button
+            className="button text-xs py-1 px-3"
+            onClick={() => setTab('questions')}
+          >
+            Ver preguntas
+          </button>
+        </div>
+      )}
+
+      <div className="mode-tabs activity-tabs">
+        {[
+          ['purchases', 'Compras'],
+          ['sales', 'Ventas'],
+          ['bids', 'Mis pujas'],
+          ['listings', 'Mis anuncios'],
+          ['questions', `Preguntas${pendingQuestionsCount > 0 ? ` (${pendingQuestionsCount})` : ''}`],
+        ].map(([v, t]) => (
+          <button
+            key={v}
+            className={tab === v ? 'active' : ''}
+            onClick={() => setTab(v)}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      {error && <p className="error-message">{error}</p>}
+
+      {!data && !error ? (
+        <p>Cargando actividad…</p>
+      ) : tab === 'questions' ? (
+        <div className="space-y-6">
+          {/* Preguntas como vendedor */}
+          <section className="border border-stone-200 rounded-xl p-5 bg-white">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-bold m-0">Preguntas recibidas en tus anuncios</h2>
+              {sellerQuestions.length > 0 && (
+                <span className="qa-badge">{sellerQuestions.length} pendientes</span>
+              )}
+            </div>
+
+            {sellerQuestions.length === 0 ? (
+              <p className="muted text-sm m-0">
+                No tienes preguntas pendientes de respuesta en tus productos.
+              </p>
+            ) : (
+              <div className="activity-list">
+                {sellerQuestions.map((q: any) => {
+                  const l = q.listing || {};
+                  const slug = productSlug(q.listing_id, l.title || 'articulo');
+                  return (
+                    <article key={q.id} className="activity-row">
+                      {l.images?.[0] && <img src={l.images[0]} alt={l.title || ''} />}
+                      <div>
+                        <h3>
+                          <Link href={`/articulos/${slug}#qa-heading`}>
+                            {l.title || 'Artículo'}
+                          </Link>
+                        </h3>
+                        <p className="font-medium text-sm text-stone-800 my-1">"{q.question}"</p>
+                        <p className="muted text-xs">
+                          Recibida el {new Date(q.created_at).toLocaleDateString('es-ES')}
+                        </p>
+                      </div>
+                      <Link className="button primary text-xs py-2 px-3" href={`/articulos/${slug}#qa-heading`}>
+                        Responder →
+                      </Link>
+                    </article>
+                  );
+                })}
+              </div>
+            )}
+          </section>
+
+          {/* Preguntas como comprador */}
+          <section className="border border-stone-200 rounded-xl p-5 bg-white">
+            <h2 className="text-lg font-bold m-0 mb-4">Tus preguntas sobre otros artículos</h2>
+            {buyerQuestions.length === 0 ? (
+              <p className="muted text-sm m-0">
+                No has realizado preguntas sobre otros productos todavía.
+              </p>
+            ) : (
+              <div className="activity-list">
+                {buyerQuestions.map((q: any) => {
+                  const l = q.listing || {};
+                  const slug = productSlug(q.listing_id, l.title || 'articulo');
+                  return (
+                    <article key={q.id} className="activity-row">
+                      {l.images?.[0] && <img src={l.images[0]} alt={l.title || ''} />}
+                      <div>
+                        <h3>
+                          <Link href={`/articulos/${slug}#qa-heading`}>
+                            {l.title || 'Artículo'}
+                          </Link>
+                        </h3>
+                        <p className="font-medium text-sm text-stone-800 my-1">"{q.question}"</p>
+                        {q.answer ? (
+                          <div className="bg-emerald-50 border border-emerald-200 rounded p-2 text-xs text-emerald-900 mt-1">
+                            <strong>Respuesta del vendedor:</strong> {q.answer}
+                          </div>
+                        ) : (
+                          <span className="qa-answer-pending text-xs">
+                            Pendiente de respuesta del vendedor
+                          </span>
+                        )}
+                      </div>
+                      <Link className="button text-xs py-2 px-3" href={`/articulos/${slug}#qa-heading`}>
+                        Ver artículo →
+                      </Link>
+                    </article>
+                  );
+                })}
+              </div>
+            )}
+          </section>
+        </div>
+      ) : !rows.length ? (
+        <div className="empty-state">
+          <h2>Todavía no hay actividad aquí</h2>
+          <p>Los artículos y pedidos aparecerán aquí cuando participes.</p>
+          <Link href="/" className="button">
+            Explorar artículos
+          </Link>
+        </div>
+      ) : (
+        <div className="activity-list">
+          {rows.map((r: any) => {
+            const l = r.listing || r;
+            const slug = productSlug(r.listing_id || r.id, l.title);
+            return (
+              <article key={r.id} className="activity-row">
+                <img src={l.images[0]} alt={l.title} />
+                <div>
+                  <h3>
+                    <Link
+                      href={
+                        tab === 'listings' || tab === 'bids'
+                          ? '/articulos/' + slug
+                          : '/orders/' + r.id
+                      }
+                    >
+                      {l.title}
+                    </Link>
+                  </h3>
+                  <p className="muted">
+                    {labels[r.status || l.status] || r.status} ·{' '}
+                    {new Date(r.created_at).toLocaleDateString('es-ES')}
+                  </p>
+                </div>
+                <strong>{money(r.amount_cents || r.price_cents)}</strong>
+                {tab === 'listings' ? (
+                  r.status === 'available' && !r.bid_count ? (
+                    <button className="button" onClick={() => setWithdraw(r.id)}>
+                      Retirar
+                    </button>
+                  ) : null
+                ) : tab !== 'bids' ? (
+                  <Link className="button" href={'/orders/' + r.id}>
+                    Ver pedido →
+                  </Link>
+                ) : (
+                  <Link className="button" href={'/articulos/' + slug}>
+                    Ver subasta →
+                  </Link>
+                )}
+              </article>
+            );
+          })}
+        </div>
+      )}
+
+      {withdraw && (
+        <div className="confirmation">
+          <h2>¿Retirar este anuncio?</h2>
+          <p>Se conservará en tu historial y dejará de estar a la venta.</p>
+          <button className="button primary" disabled={busy} onClick={remove}>
+            Retirar anuncio
+          </button>
+          <button className="button" onClick={() => setWithdraw('')}>
+            Cancelar
+          </button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/ProductDetailInteractive.tsx
+++ b/src/components/ProductDetailInteractive.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import {api} from '@/lib/api';
 import {money} from '@/lib/rules';
 import {useAuth} from '@/context/AuthContext';
+import ProductQA from './ProductQA';
 
 interface ProductDetailInteractiveProps {
   initialItem: any;
@@ -101,6 +102,17 @@ export default function ProductDetailInteractive({initialItem, slug, demo = fals
           </div>
         )}
         <div className="detail-description">
+          {item.mine && (item.pendingQuestionsCount || 0) > 0 && (
+            <div className="seller-alert-banner" role="status">
+              <div>
+                <strong>Tienes {item.pendingQuestionsCount} pregunta{item.pendingQuestionsCount === 1 ? '' : 's'} sin responder.</strong>
+                <p className="m-0 text-xs text-emerald-900">Los compradores potenciales tienen dudas sobre este artículo.</p>
+              </div>
+              <a href="#qa-heading" className="button text-xs py-1 px-3">
+                Ver preguntas ↓
+              </a>
+            </div>
+          )}
           <h2>Todo sobre este artículo</h2>
           <div className="detail-chips">
             <span>{item.condition}</span>
@@ -115,6 +127,13 @@ export default function ProductDetailInteractive({initialItem, slug, demo = fals
               : `Recogida en persona en ${item.location}. La dirección exacta se acuerda tras el pago.`}
           </p>
         </div>
+
+        <ProductQA
+          listingId={item.id}
+          isSeller={!!item.mine}
+          user={user}
+          demo={demo}
+        />
       </section>
 
       <aside className="purchase-panel">

--- a/src/components/ProductQA.tsx
+++ b/src/components/ProductQA.tsx
@@ -1,0 +1,344 @@
+'use client';
+import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
+import { api } from '@/lib/api';
+
+export interface QuestionItem {
+  id: string;
+  listing_id: string;
+  buyer_id: string;
+  seller_id: string;
+  question: string;
+  answer: string | null;
+  created_at: string;
+  answered_at: string | null;
+}
+
+interface ProductQAProps {
+  listingId: string;
+  isSeller: boolean;
+  user: any;
+  demo?: boolean;
+}
+
+export default function ProductQA({ listingId, isSeller, user, demo = false }: ProductQAProps) {
+  const [questions, setQuestions] = useState<QuestionItem[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [pendingCount, setPendingCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+
+  const [newQuestion, setNewQuestion] = useState('');
+  const [submittingQuestion, setSubmittingQuestion] = useState(false);
+  const [questionError, setQuestionError] = useState('');
+  const [questionSuccess, setQuestionSuccess] = useState('');
+
+  const [answeringId, setAnsweringId] = useState<string | null>(null);
+  const [answerDrafts, setAnswerDrafts] = useState<Record<string, string>>({});
+  const [submittingAnswer, setSubmittingAnswer] = useState(false);
+  const [answerError, setAnswerError] = useState('');
+
+  const loadQuestions = useCallback(async (targetPage: number) => {
+    if (!listingId || demo) {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await api(`questions/${listingId}?page=${targetPage}`);
+      setQuestions(res.questions || []);
+      setTotalCount(res.totalCount || 0);
+      setPage(res.page || 1);
+      setTotalPages(res.totalPages || 1);
+      setPendingCount(res.pendingCount || 0);
+    } catch {
+      // If error or endpoint unreachable
+    } finally {
+      setLoading(false);
+    }
+  }, [listingId, demo]);
+
+  useEffect(() => {
+    loadQuestions(1);
+  }, [loadQuestions]);
+
+  async function handleAskSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setQuestionError('');
+    setQuestionSuccess('');
+
+    const clean = newQuestion.trim();
+    if (clean.length < 5) {
+      setQuestionError('La pregunta debe tener al menos 5 caracteres.');
+      return;
+    }
+    if (clean.length > 1000) {
+      setQuestionError('La pregunta no puede superar los 1000 caracteres.');
+      return;
+    }
+
+    setSubmittingQuestion(true);
+    try {
+      await api(`question/${listingId}`, { question: clean });
+      setNewQuestion('');
+      setQuestionSuccess('Tu pregunta se ha publicado. El vendedor podrá responderla públicamente.');
+      await loadQuestions(1);
+    } catch (err) {
+      setQuestionError((err as Error).message || 'No se ha podido enviar la pregunta.');
+    } finally {
+      setSubmittingQuestion(false);
+    }
+  }
+
+  async function handleAnswerSubmit(questionId: string) {
+    setAnswerError('');
+    const draft = (answerDrafts[questionId] || '').trim();
+    if (draft.length < 2) {
+      setAnswerError('La respuesta debe tener al menos 2 caracteres.');
+      return;
+    }
+    if (draft.length > 1000) {
+      setAnswerError('La respuesta no puede superar los 1000 caracteres.');
+      return;
+    }
+
+    setSubmittingAnswer(true);
+    try {
+      await api(`answer/${questionId}`, { answer: draft });
+      setAnsweringId(null);
+      setAnswerDrafts((prev) => ({ ...prev, [questionId]: '' }));
+      await loadQuestions(page);
+    } catch (err) {
+      setAnswerError((err as Error).message || 'No se ha podido publicar la respuesta.');
+    } finally {
+      setSubmittingAnswer(false);
+    }
+  }
+
+  return (
+    <section className="qa-section" aria-labelledby="qa-heading">
+      <div className="flex items-center justify-between gap-4 mb-4">
+        <h2 id="qa-heading" className="text-xl font-bold m-0">
+          Preguntas y respuestas {totalCount > 0 && <span className="muted font-normal text-base">({totalCount})</span>}
+        </h2>
+        {isSeller && pendingCount > 0 && (
+          <span className="qa-badge" title="Preguntas sin responder en este anuncio">
+            {pendingCount} pendiente{pendingCount === 1 ? '' : 's'}
+          </span>
+        )}
+      </div>
+
+      <div className="qa-rule-banner">
+        <strong>Normativa de la sección de preguntas:</strong>
+        <ul>
+          <li>
+            Las preguntas deben ceñirse a la <strong>naturaleza, detalles, especificaciones o estado</strong> del producto.
+          </li>
+          <li>
+            <strong>Sin regateos ni contraofertas:</strong> en La Pela el precio es cerrado (o se fija por pujas en subastas).
+          </li>
+          <li>
+            <strong>Privacidad:</strong> no compartas teléfonos, correos electrónicos ni enlaces externos.
+          </li>
+        </ul>
+      </div>
+
+      {/* Formulario para hacer una pregunta */}
+      {demo ? (
+        <div className="notice mb-6">
+          En los anuncios de ejemplo no está habilitada la publicación de preguntas.
+        </div>
+      ) : isSeller ? (
+        <div className="notice mb-6">
+          Este es tu anuncio. A continuación puedes revisar las preguntas recibidas y responder a los compradores potenciales.
+        </div>
+      ) : !user ? (
+        <div className="notice mb-6">
+          ¿Tienes alguna duda sobre este artículo?{' '}
+          <Link href="/login" className="underline font-semibold text-emerald-800">
+            Inicia sesión
+          </Link>{' '}
+          para preguntar al vendedor.
+        </div>
+      ) : (
+        <form onSubmit={handleAskSubmit} className="qa-form">
+          <label htmlFor="qa-new-question" className="block font-semibold mb-2 text-sm">
+            Preguntar al vendedor
+          </label>
+          <textarea
+            id="qa-new-question"
+            className="field-input"
+            rows={3}
+            placeholder="Escribe tu duda sobre las características o estado del producto…"
+            value={newQuestion}
+            onChange={(e) => setNewQuestion(e.target.value)}
+            disabled={submittingQuestion}
+            maxLength={1000}
+            required
+          />
+          <div className="flex items-center justify-between text-xs text-stone-500 mb-3">
+            <span>Mínimo 5 caracteres · Sin datos de contacto ni regateos</span>
+            <span>{newQuestion.length} / 1000</span>
+          </div>
+
+          {questionError && (
+            <p className="error-message mb-3" role="alert">
+              {questionError}
+            </p>
+          )}
+          {questionSuccess && (
+            <div className="notice mb-3" role="status">
+              {questionSuccess}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            className="button primary"
+            disabled={submittingQuestion || newQuestion.trim().length < 5}
+          >
+            {submittingQuestion ? 'Enviando pregunta…' : 'Enviar pregunta'}
+          </button>
+        </form>
+      )}
+
+      {/* Listado de preguntas */}
+      <div className="qa-list">
+        {loading ? (
+          <p className="muted py-4">Cargando preguntas…</p>
+        ) : questions.length === 0 ? (
+          <div className="empty-state">
+            <p className="m-0 font-medium">Aún no hay preguntas sobre este artículo.</p>
+            <p className="muted text-sm mt-1 mb-0">
+              Si tienes dudas sobre las medidas, estado o funcionamiento, ¡sé el primero en preguntar!
+            </p>
+          </div>
+        ) : (
+          questions.map((q) => (
+            <article key={q.id} className="qa-card">
+              <div className="qa-question">
+                <p>{q.question}</p>
+                <div className="qa-meta">
+                  <span>
+                    Preguntado el{' '}
+                    {new Date(q.created_at).toLocaleDateString('es-ES', {
+                      day: 'numeric',
+                      month: 'short',
+                      year: 'numeric',
+                    })}
+                  </span>
+                </div>
+              </div>
+
+              {/* Respuesta existente */}
+              {q.answer ? (
+                <div className="qa-answer">
+                  <div className="qa-answer-title">Respuesta del vendedor:</div>
+                  <p>{q.answer}</p>
+                  {q.answered_at && (
+                    <div className="qa-meta mt-1">
+                      <span>
+                        Respondido el{' '}
+                        {new Date(q.answered_at).toLocaleDateString('es-ES', {
+                          day: 'numeric',
+                          month: 'short',
+                          year: 'numeric',
+                        })}
+                      </span>
+                    </div>
+                  )}
+                </div>
+              ) : isSeller ? (
+                /* Formulario de respuesta para el vendedor */
+                <div className="qa-answer-form">
+                  {answeringId === q.id ? (
+                    <div>
+                      <label htmlFor={`answer-${q.id}`} className="block font-semibold text-xs mb-1">
+                        Tu respuesta pública:
+                      </label>
+                      <textarea
+                        id={`answer-${q.id}`}
+                        className="field-input"
+                        rows={2}
+                        placeholder="Escribe una respuesta clara sobre las características del producto…"
+                        value={answerDrafts[q.id] || ''}
+                        onChange={(e) =>
+                          setAnswerDrafts((prev) => ({ ...prev, [q.id]: e.target.value }))
+                        }
+                        maxLength={1000}
+                        disabled={submittingAnswer}
+                      />
+                      {answerError && (
+                        <p className="error-message text-xs py-2 px-3 mb-2" role="alert">
+                          {answerError}
+                        </p>
+                      )}
+                      <div className="flex gap-2">
+                        <button
+                          type="button"
+                          className="button primary text-sm py-2 px-4 min-h-0"
+                          disabled={submittingAnswer || !(answerDrafts[q.id] || '').trim()}
+                          onClick={() => handleAnswerSubmit(q.id)}
+                        >
+                          {submittingAnswer ? 'Publicando…' : 'Publicar respuesta'}
+                        </button>
+                        <button
+                          type="button"
+                          className="button text-sm py-2 px-4 min-h-0"
+                          disabled={submittingAnswer}
+                          onClick={() => {
+                            setAnsweringId(null);
+                            setAnswerError('');
+                          }}
+                        >
+                          Cancelar
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <button
+                      type="button"
+                      className="button secondary text-sm py-2 px-3 min-h-0"
+                      onClick={() => {
+                        setAnsweringId(q.id);
+                        setAnswerError('');
+                      }}
+                    >
+                      Responder a esta pregunta
+                    </button>
+                  )}
+                </div>
+              ) : (
+                <span className="qa-answer-pending">Pendiente de respuesta del vendedor</span>
+              )}
+            </article>
+          ))
+        )}
+      </div>
+
+      {/* Paginación */}
+      {totalPages > 1 && (
+        <nav className="qa-pagination" aria-label="Navegación de preguntas">
+          <button
+            className="button text-sm py-2 px-3"
+            disabled={page <= 1 || loading}
+            onClick={() => loadQuestions(page - 1)}
+          >
+            ← Anterior
+          </button>
+          <span className="text-sm muted">
+            Página {page} de {totalPages}
+          </span>
+          <button
+            className="button text-sm py-2 px-3"
+            disabled={page >= totalPages || loading}
+            onClick={() => loadQuestions(page + 1)}
+          >
+            Siguiente →
+          </button>
+        </nav>
+      )}
+    </section>
+  );
+}

--- a/src/components/__tests__/ProductQA.test.tsx
+++ b/src/components/__tests__/ProductQA.test.tsx
@@ -1,0 +1,186 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ProductQA from '../ProductQA';
+import { api } from '@/lib/api';
+
+jest.mock('@/lib/api', () => ({
+  api: jest.fn(),
+}));
+
+jest.mock('next/link', () => {
+  return ({ children, href }: { children: React.ReactNode; href: string }) => {
+    return <a href={href}>{children}</a>;
+  };
+});
+
+const mockedApi = api as jest.MockedFunction<typeof api>;
+
+describe('ProductQA Component (LP-FEAT-005)', () => {
+  const mockQuestions = [
+    {
+      id: 'q-1',
+      listing_id: 'item-1',
+      buyer_id: 'buyer-1',
+      seller_id: 'seller-1',
+      question: '¿Tiene algún golpe en las esquinas?',
+      answer: 'No, está en perfecto estado siempre con funda.',
+      created_at: new Date('2026-09-01T10:00:00Z').toISOString(),
+      answered_at: new Date('2026-09-01T12:00:00Z').toISOString(),
+    },
+    {
+      id: 'q-2',
+      listing_id: 'item-1',
+      buyer_id: 'buyer-2',
+      seller_id: 'seller-1',
+      question: '¿Incluye el cargador original?',
+      answer: null,
+      created_at: new Date('2026-09-02T10:00:00Z').toISOString(),
+      answered_at: null,
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders Q&A heading and policy banner against bargaining and contact info', async () => {
+    mockedApi.mockResolvedValueOnce({
+      questions: [],
+      totalCount: 0,
+      page: 1,
+      totalPages: 1,
+      pendingCount: 0,
+    });
+
+    render(<ProductQA listingId="item-1" isSeller={false} user={null} />);
+
+    expect(await screen.findByRole('heading', { name: /Preguntas y respuestas/i })).toBeInTheDocument();
+    expect(screen.getByText(/Sin regateos ni contraofertas/i)).toBeInTheDocument();
+    expect(screen.getByText(/no compartas teléfonos, correos electrónicos/i)).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText(/Cargando preguntas/i)).not.toBeInTheDocument());
+  });
+
+  it('shows login prompt for unauthenticated users', async () => {
+    mockedApi.mockResolvedValueOnce({
+      questions: [],
+      totalCount: 0,
+      page: 1,
+      totalPages: 1,
+      pendingCount: 0,
+    });
+
+    render(<ProductQA listingId="item-1" isSeller={false} user={null} />);
+
+    expect(await screen.findByText(/Inicia sesión/i)).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText(/Cargando preguntas/i)).not.toBeInTheDocument());
+  });
+
+  it('displays questions, seller answers, and pending status', async () => {
+    mockedApi.mockResolvedValueOnce({
+      questions: mockQuestions,
+      totalCount: 2,
+      page: 1,
+      totalPages: 1,
+      pendingCount: 1,
+    });
+
+    render(<ProductQA listingId="item-1" isSeller={false} user={{ id: 'buyer-3' }} />);
+
+    expect(await screen.findByText('¿Tiene algún golpe en las esquinas?')).toBeInTheDocument();
+    expect(screen.getByText('No, está en perfecto estado siempre con funda.')).toBeInTheDocument();
+    expect(screen.getByText('¿Incluye el cargador original?')).toBeInTheDocument();
+    expect(screen.getByText('Pendiente de respuesta del vendedor')).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText(/Cargando preguntas/i)).not.toBeInTheDocument());
+  });
+
+  it('allows prospective buyers to ask questions with validation', async () => {
+    mockedApi
+      .mockResolvedValueOnce({
+        questions: [],
+        totalCount: 0,
+        page: 1,
+        totalPages: 1,
+        pendingCount: 0,
+      })
+      .mockResolvedValueOnce({ id: 'q-new' }) // POST question
+      .mockResolvedValueOnce({
+        questions: [
+          {
+            id: 'q-new',
+            listing_id: 'item-1',
+            buyer_id: 'buyer-3',
+            seller_id: 'seller-1',
+            question: '¿Tiene factura de compra?',
+            answer: null,
+            created_at: new Date().toISOString(),
+            answered_at: null,
+          },
+        ],
+        totalCount: 1,
+        page: 1,
+        totalPages: 1,
+        pendingCount: 1,
+      });
+
+    render(<ProductQA listingId="item-1" isSeller={false} user={{ id: 'buyer-3' }} />);
+
+    const textarea = await screen.findByLabelText(/Preguntar al vendedor/i);
+    await waitFor(() => expect(screen.queryByText(/Cargando preguntas/i)).not.toBeInTheDocument());
+
+    const submitButton = screen.getByRole('button', { name: /Enviar pregunta/i });
+    expect(submitButton).toBeDisabled();
+
+    fireEvent.change(textarea, { target: { value: '¿Tiene factura de compra?' } });
+    expect(submitButton).not.toBeDisabled();
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockedApi).toHaveBeenCalledWith('question/item-1', {
+        question: '¿Tiene factura de compra?',
+      });
+    });
+    await waitFor(() => expect(screen.getByText('¿Tiene factura de compra?')).toBeInTheDocument());
+  });
+
+  it('allows the seller to reply to unanswered questions', async () => {
+    mockedApi
+      .mockResolvedValueOnce({
+        questions: mockQuestions,
+        totalCount: 2,
+        page: 1,
+        totalPages: 1,
+        pendingCount: 1,
+      })
+      .mockResolvedValueOnce({ id: 'q-2', answer: 'Sí, incluye el cargador.' }) // POST answer
+      .mockResolvedValueOnce({
+        questions: [
+          mockQuestions[0],
+          { ...mockQuestions[1], answer: 'Sí, incluye el cargador.', answered_at: new Date().toISOString() },
+        ],
+        totalCount: 2,
+        page: 1,
+        totalPages: 1,
+        pendingCount: 0,
+      });
+
+    render(<ProductQA listingId="item-1" isSeller={true} user={{ id: 'seller-1' }} />);
+
+    const respondButton = await screen.findByRole('button', { name: /Responder a esta pregunta/i });
+    await waitFor(() => expect(screen.queryByText(/Cargando preguntas/i)).not.toBeInTheDocument());
+
+    fireEvent.click(respondButton);
+
+    const answerInput = screen.getByLabelText(/Tu respuesta pública/i);
+    fireEvent.change(answerInput, { target: { value: 'Sí, incluye el cargador.' } });
+
+    const publishButton = screen.getByRole('button', { name: /Publicar respuesta/i });
+    fireEvent.click(publishButton);
+
+    await waitFor(() => {
+      expect(mockedApi).toHaveBeenCalledWith('answer/q-2', {
+        answer: 'Sí, incluye el cargador.',
+      });
+    });
+    await waitFor(() => expect(screen.getByText('Sí, incluye el cargador.')).toBeInTheDocument());
+  });
+});

--- a/src/controllers/marketplace.ts
+++ b/src/controllers/marketplace.ts
@@ -1,7 +1,7 @@
 import {NextResponse} from 'next/server';
 import {createClient} from '@/utils/supabase/server';
 import {admin,card,publicFields,rpc} from '@/models/marketplace';
-import {categories,conditions,cents,text,noContact,uuid,canMessage} from '@/lib/rules';
+import {categories,conditions,cents,text,noContact,noBargaining,uuid,canMessage} from '@/lib/rules';
 import {stripe,origin} from '@/lib/payments';
 import {extractIdFromSlug,productSlug} from '@/lib/slugs';
 export async function currentUser(){const client=await createClient();const {data:{user}}=await client.auth.getUser();return user}
@@ -14,9 +14,17 @@ export async function catalog(request:Request){try{await maintain();const p=new 
 export async function handle(request:Request,path:string[]){try{
  const db=admin();const [action,id]=path;const targetId=extractIdFromSlug(id||'');const user=await currentUser();
  if(request.method==='GET'){
-  if(action==='listing'&&targetId&&uuid(targetId)){await maintain();const l=await result(db.from('lp_listings').select('*').eq('id',targetId).maybeSingle());if(!l||l.environment!==environment())return ok({error:'Artículo no encontrado'},404);const mine=l.seller_id===user?.id;const {seller_id,highest_bidder,...safe}=l;return ok({...safe,slug:productSlug(l.id,l.title),mine,isHighestBidder:!!user&&highest_bidder===user.id,paymentsReady:simulated()||!!process.env.STRIPE_SECRET_KEY,simulated:simulated()});}
+  if(action==='questions'&&targetId&&uuid(targetId)){
+   const p=new URL(request.url).searchParams;
+   const page=Math.max(1,Math.min(1000,Number.parseInt(p.get('page')||'1')||1));
+   const {data,error,count}=await db.from('lp_questions').select('id,listing_id,buyer_id,seller_id,question,answer,created_at,answered_at',{count:'exact'}).eq('listing_id',targetId).order('created_at',{ascending:false}).range((page-1)*10,page*10-1);
+   if(error)throw error;
+   const pending=user?await db.from('lp_questions').select('id',{head:true,count:'exact'}).eq('listing_id',targetId).is('answer',null):{count:0};
+   return ok({questions:data||[],totalCount:count||0,page,pageSize:10,totalPages:Math.max(1,Math.ceil((count||0)/10)),pendingCount:pending.count||0});
+  }
+  if(action==='listing'&&targetId&&uuid(targetId)){await maintain();const l=await result(db.from('lp_listings').select('*').eq('id',targetId).maybeSingle());if(!l||l.environment!==environment())return ok({error:'Artículo no encontrado'},404);const mine=l.seller_id===user?.id;const {seller_id,highest_bidder,...safe}=l;let pendingQuestions=0;if(mine){const pq=await db.from('lp_questions').select('id',{head:true,count:'exact'}).eq('listing_id',targetId).is('answer',null);pendingQuestions=pq.count||0;}return ok({...safe,slug:productSlug(l.id,l.title),mine,isHighestBidder:!!user&&highest_bidder===user.id,paymentsReady:simulated()||!!process.env.STRIPE_SECRET_KEY,simulated:simulated(),pendingQuestionsCount:pendingQuestions});}
   if(!user)return ok({error:'Inicia sesión para continuar.'},401);
-  if(action==='activity'){await maintain();const [listings,orders,bids]=await Promise.all([result(db.from('lp_listings').select('*').eq('seller_id',user.id).order('created_at',{ascending:false})),result(db.from('lp_orders').select('*,listing:lp_listings(title,images,delivery)').or(`buyer_id.eq.${user.id},seller_id.eq.${user.id}`).order('created_at',{ascending:false})),result(db.from('lp_bids').select('*,listing:lp_listings(title,images,price_cents,ends_at,status)').eq('bidder_id',user.id).order('created_at',{ascending:false}))]);return ok({listings,orders,bids,userId:user.id})}
+  if(action==='activity'){await maintain();const [listings,orders,bids,sellerQuestions,buyerQuestions]=await Promise.all([result(db.from('lp_listings').select('*').eq('seller_id',user.id).order('created_at',{ascending:false})),result(db.from('lp_orders').select('*,listing:lp_listings(title,images,delivery)').or(`buyer_id.eq.${user.id},seller_id.eq.${user.id}`).order('created_at',{ascending:false})),result(db.from('lp_bids').select('*,listing:lp_listings(title,images,price_cents,ends_at,status)').eq('bidder_id',user.id).order('created_at',{ascending:false})),result(db.from('lp_questions').select('*,listing:lp_listings(title,images)').eq('seller_id',user.id).is('answer',null).order('created_at',{ascending:false})),result(db.from('lp_questions').select('*,listing:lp_listings(title,images)').eq('buyer_id',user.id).order('created_at',{ascending:false}))]);return ok({listings,orders,bids,sellerQuestions:sellerQuestions||[],buyerQuestions:buyerQuestions||[],pendingQuestionsCount:(sellerQuestions||[]).length,userId:user.id})}
   if(action==='order'&&uuid(id||'')){const o=await result(db.from('lp_orders').select('*,listing:lp_listings(title,images,delivery,location)').eq('id',id).or(`buyer_id.eq.${user.id},seller_id.eq.${user.id}`).maybeSingle());if(!o)return ok({error:'Pedido no encontrado'},404);const allowed=canMessage(o.status,user.id,o.buyer_id,o.seller_id);const messages=allowed?await result(db.from('lp_messages').select('*').eq('order_id',id).order('created_at').limit(500)):[];if(!allowed)o.shipping_address=null;return ok({order:o,messages,userId:user.id,simulated:simulated(),canMessage:allowed})}
  }
  if(request.method!=='POST')return ok({error:'Ruta no encontrada'},404);
@@ -59,6 +67,18 @@ export async function handle(request:Request,path:string[]){try{
  if(action==='report'&&uuid(targetId||'')){await result(db.from('lp_reports').insert({reporter_id:user.id,listing_id:targetId,reason:text(body.reason,10,2000)}));return ok({success:true})}
  if(action==='onboard'){if(simulated())return ok({error:'Estás en modo de prueba. No necesitas activar cobros reales.'},400);
   const st=stripe();const base=origin();let account=await result(db.from('lp_accounts').select('stripe_account_id').eq('user_id',user.id).maybeSingle());if(!account){const a=await st.accounts.create({type:'express',country:'ES',email:user.email,capabilities:{card_payments:{requested:true},transfers:{requested:true}},metadata:{user_id:user.id}},{idempotencyKey:'lapela-account-'+user.id});account={stripe_account_id:a.id};await result(db.from('lp_accounts').upsert({user_id:user.id,...account},{onConflict:'user_id'}))}const link=await st.accountLinks.create({account:account.stripe_account_id,refresh_url:base+'/user-profile',return_url:base+'/user-profile',type:'account_onboarding'});return ok({url:link.url});
+ }
+ if(action==='question'&&uuid(targetId||'')){
+  const q=noBargaining(noContact(text(body.question,5,1000)));
+  const recent=await db.from('lp_questions').select('id',{head:true,count:'exact'}).eq('buyer_id',user.id).gte('created_at',new Date(Date.now()-3600000).toISOString());
+  if((recent.count||0)>=10)return ok({error:'Has alcanzado el límite de preguntas por hora.'},429);
+  const created=await rpc('lp_ask_question',{p_listing:targetId,p_actor:user.id,p_question:q});
+  return ok(created,201);
+ }
+ if(action==='answer'&&uuid(id||'')){
+  const ans=noContact(text(body.answer,2,1000));
+  const updated=await rpc('lp_answer_question',{p_question_id:id,p_actor:user.id,p_answer:ans});
+  return ok(updated);
  }
  return ok({error:'Ruta no encontrada'},404);
  }catch(e){const message=e instanceof Error?e.message:'No se ha podido completar la operación.';return ok({error:message},400)}}

--- a/src/lib/__tests__/rules-qa.test.ts
+++ b/src/lib/__tests__/rules-qa.test.ts
@@ -1,0 +1,34 @@
+import { noBargaining, noContact } from '../rules';
+
+describe('Domain rules for Q&A (LP-FEAT-005)', () => {
+  describe('noBargaining', () => {
+    it('allows valid product questions regarding state and description', () => {
+      expect(noBargaining('¿Viene con caja original y cables?')).toBe('¿Viene con caja original y cables?');
+      expect(noBargaining('¿Tiene algún golpe en las esquinas o marcas de uso?')).toBe('¿Tiene algún golpe en las esquinas o marcas de uso?');
+      expect(noBargaining('¿De qué año es el modelo?')).toBe('¿De qué año es el modelo?');
+    });
+
+    it('rejects bargaining attempts', () => {
+      expect(() => noBargaining('¿Aceptas regateo?')).toThrow(/no es negociable/);
+      expect(() => noBargaining('Te doy 50 euros y me lo llevo')).toThrow(/no es negociable/);
+      expect(() => noBargaining('¿Me haces una rebaja?')).toThrow(/no es negociable/);
+      expect(() => noBargaining('¿Cuál es tu último precio?')).toThrow(/no es negociable/);
+      expect(() => noBargaining('¿Haces algún descuento si recojo hoy?')).toThrow(/no es negociable/);
+      expect(() => noBargaining('¿El precio es negociable?')).toThrow(/no es negociable/);
+      expect(() => noBargaining('¿Podrías bajar el precio?')).toThrow(/no es negociable/);
+    });
+  });
+
+  describe('noContact', () => {
+    it('allows normal questions without contact info', () => {
+      expect(noContact('¿Funciona la batería al 100%?')).toBe('¿Funciona la batería al 100%?');
+    });
+
+    it('rejects contact details in questions', () => {
+      expect(() => noContact('Escríbeme a test@example.com')).toThrow(/No incluyas teléfonos, enlaces/);
+      expect(() => noContact('Mi teléfono es 612345678, llámame')).toThrow(/No incluyas teléfonos, enlaces/);
+      expect(() => noContact('Hablamos por whatsapp')).toThrow(/No incluyas teléfonos, enlaces/);
+      expect(() => noContact('Búscame en instagram @usuario')).toThrow(/No incluyas teléfonos, enlaces/);
+    });
+  });
+});

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -3,6 +3,9 @@ export const conditions=['Como nuevo','Buen estado','Con señales de uso'];
 export const money=(cents:number)=>new Intl.NumberFormat('es-ES',{style:'currency',currency:'EUR'}).format(cents/100);
 export function cents(value:unknown){const n=Number(value);if(!Number.isFinite(n)||n<1||n>10000||Math.abs(n*100-Math.round(n*100))>0.00001)throw Error('Indica un importe entre 1 y 10.000 €, con un máximo de dos decimales.');return Math.round(n*100)}
 export function text(value:unknown,min:number,max:number){if(typeof value!=='string'||value.trim().length<min||value.trim().length>max)throw Error(`El texto debe tener entre ${min} y ${max} caracteres.`);return value.trim()}
-export function noContact(value:string){if(/https?:|www\.|\b[\w.+-]+@[\w.-]+\.[a-z]{2,}|(?:\+34[\s.-]*)?(?:\d[\s.-]*){9,}|whats?app|telegram|instagram|@[a-z0-9_]{3,}/i.test(value))throw Error('No incluyas teléfonos, enlaces ni datos de contacto en el anuncio.');return value}
+export function noContact(value:string){if(/https?:|www\.|\b[\w.+-]+@[\w.-]+\.[a-z]{2,}|(?:\+34[\s.-]*)?(?:\d[\s.-]*){9,}|whats?app|telegram|instagram|@[a-z0-9_]{3,}/i.test(value))throw Error('No incluyas teléfonos, enlaces ni datos de contacto.');return value}
+export function noBargaining(value:string){if(/(?:^|[^\p{L}\p{N}])(?:regate[ao]|regatear|te doy|te ofrezco|rebaj[ao]|rebajas|rebajar|descuento|[uú]ltimo precio|precio m[ií]nimo|bajar(?:lo|le)? el precio|negociable|contraoferta)(?:$|[^\p{L}\p{N}])/iu.test(value))throw Error('En La Pela el precio no es negociable. Las preguntas deben tratar sobre las características o estado del producto.');return value}
+
 export const uuid=(s:string)=>/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(s);
 export function canMessage(status:string,actor:string,buyer:string,seller:string){return ['paid','shipped','completed','disputed'].includes(status)&&[buyer,seller].includes(actor)}
+

--- a/supabase/migrations/202609060005_product_qa.sql
+++ b/supabase/migrations/202609060005_product_qa.sql
@@ -1,0 +1,96 @@
+begin;
+
+create table if not exists public.lp_questions (
+  id uuid primary key default gen_random_uuid(),
+  listing_id uuid not null references public.lp_listings(id) on delete cascade,
+  buyer_id uuid not null references auth.users(id),
+  seller_id uuid not null references auth.users(id),
+  question text not null check(length(trim(question)) between 5 and 1000),
+  answer text check(answer is null or length(trim(answer)) between 2 and 1000),
+  created_at timestamptz not null default now(),
+  answered_at timestamptz,
+  seller_notified boolean not null default false,
+  buyer_notified boolean not null default false,
+  check (buyer_id <> seller_id)
+);
+
+create index if not exists lp_questions_listing_idx on public.lp_questions(listing_id, created_at desc);
+create index if not exists lp_questions_seller_pending_idx on public.lp_questions(seller_id, created_at desc) where answer is null;
+create index if not exists lp_questions_buyer_idx on public.lp_questions(buyer_id, created_at desc);
+
+alter table public.lp_questions enable row level security;
+revoke all on public.lp_questions from anon, authenticated;
+grant all on public.lp_questions to service_role;
+
+create or replace function public.lp_ask_question(
+  p_listing uuid,
+  p_actor uuid,
+  p_question text
+) returns public.lp_questions language plpgsql security definer set search_path=public as $$
+declare
+  l public.lp_listings;
+  q public.lp_questions;
+  clean_question text;
+begin
+  clean_question := trim(p_question);
+  if length(clean_question) < 5 or length(clean_question) > 1000 then
+    raise exception 'La pregunta debe tener entre 5 y 1000 caracteres';
+  end if;
+
+  select * into l from lp_listings where id = p_listing for update;
+  if not found then
+    raise exception 'Artículo no encontrado';
+  end if;
+
+  if l.seller_id = p_actor then
+    raise exception 'No puedes hacer preguntas en tu propio anuncio';
+  end if;
+
+  if l.status not in ('available', 'reserved') then
+    raise exception 'Este artículo ya no admite preguntas';
+  end if;
+
+  insert into lp_questions(listing_id, buyer_id, seller_id, question)
+  values(l.id, p_actor, l.seller_id, clean_question)
+  returning * into q;
+
+  return q;
+end $$;
+
+create or replace function public.lp_answer_question(
+  p_question_id uuid,
+  p_actor uuid,
+  p_answer text
+) returns public.lp_questions language plpgsql security definer set search_path=public as $$
+declare
+  q public.lp_questions;
+  clean_answer text;
+begin
+  clean_answer := trim(p_answer);
+  if length(clean_answer) < 2 or length(clean_answer) > 1000 then
+    raise exception 'La respuesta debe tener entre 2 y 1000 caracteres';
+  end if;
+
+  select * into q from lp_questions where id = p_question_id for update;
+  if not found then
+    raise exception 'Pregunta no encontrada';
+  end if;
+
+  if q.seller_id <> p_actor then
+    raise exception 'Solo el vendedor del producto puede responder a esta pregunta';
+  end if;
+
+  update lp_questions
+  set answer = clean_answer,
+      answered_at = now(),
+      seller_notified = true
+  where id = q.id
+  returning * into q;
+
+  return q;
+end $$;
+
+revoke execute on function public.lp_ask_question(uuid, uuid, text), public.lp_answer_question(uuid, uuid, text) from public, anon, authenticated;
+grant execute on function public.lp_ask_question(uuid, uuid, text), public.lp_answer_question(uuid, uuid, text) to service_role;
+
+commit;

--- a/tests/database/marketplace.sql
+++ b/tests/database/marketplace.sql
@@ -1,11 +1,17 @@
 begin;
 -- Everything in this test is rolled back, including the synthetic accounts.
 do $$
-declare seller uuid:=gen_random_uuid(); buyer uuid:=gen_random_uuid(); outsider uuid:=gen_random_uuid(); item uuid; auction uuid; ord public.lp_orders; l public.lp_listings; blocked boolean;
+declare seller uuid:=gen_random_uuid(); buyer uuid:=gen_random_uuid(); outsider uuid:=gen_random_uuid(); item uuid; auction uuid; ord public.lp_orders; l public.lp_listings; q public.lp_questions; blocked boolean;
 begin
  insert into auth.users(id,email,raw_user_meta_data,raw_app_meta_data,aud,role,created_at,updated_at)
  values(seller,'lp-test-seller-'||seller||'@example.invalid','{}','{}','authenticated','authenticated',now(),now()),(buyer,'lp-test-buyer-'||buyer||'@example.invalid','{}','{}','authenticated','authenticated',now(),now()),(outsider,'lp-test-other-'||outsider||'@example.invalid','{}','{}','authenticated','authenticated',now(),now());
  insert into public.lp_listings(seller_id,title,description,category,condition,location,images,mode,price_cents,delivery) values(seller,'Artículo de prueba','Descripción completa de un artículo sintético para validación.','Hogar','Buen estado','Madrid',array['https://example.invalid/test.jpg'],'sale',2000,'pickup') returning id into item;
+ blocked:=false;begin perform lp_ask_question(item,seller,'¿Puedo preguntarme a mí mismo?');exception when others then blocked:=true;end;if not blocked then raise exception 'FAIL self question';end if;
+ q:=lp_ask_question(item,buyer,'¿Incluye la caja original y accesorios?');
+ if q.buyer_id<>buyer or q.seller_id<>seller or q.question<>'¿Incluye la caja original y accesorios?' or q.answer is not null then raise exception 'FAIL ask question';end if;
+ blocked:=false;begin perform lp_answer_question(q.id,outsider,'Respuesta de tercero no autorizado');exception when others then blocked:=true;end;if not blocked then raise exception 'FAIL outsider answer';end if;
+ q:=lp_answer_question(q.id,seller,'Sí, incluye caja y cargador.');
+ if q.answer<>'Sí, incluye caja y cargador.' or q.answered_at is null then raise exception 'FAIL seller answer';end if;
  blocked:=false;begin perform lp_reserve(item,seller);exception when others then blocked:=true;end;if not blocked then raise exception 'FAIL self purchase';end if;
  ord:=lp_reserve(item,buyer);
  if ord.amount_cents<>2000 or ord.status<>'pending_payment' then raise exception 'FAIL reservation';end if;
@@ -28,7 +34,8 @@ begin
  perform lp_close_auctions();perform lp_close_auctions();
  if (select count(*) from lp_orders where listing_id=auction)<>1 then raise exception 'FAIL close idempotency';end if;
  if not exists(select 1 from lp_orders where listing_id=auction and buyer_id=outsider and amount_cents=1100) then raise exception 'FAIL winner';end if;
- if has_table_privilege('anon','lp_messages','SELECT') or has_table_privilege('authenticated','lp_orders','UPDATE') or has_function_privilege('authenticated','lp_confirm_payment(text,uuid,text,text,integer,jsonb)','EXECUTE') then raise exception 'FAIL direct privilege';end if;
+ if has_table_privilege('anon','lp_messages','SELECT') or has_table_privilege('authenticated','lp_orders','UPDATE') or has_function_privilege('authenticated','lp_confirm_payment(text,uuid,text,text,integer,jsonb)','EXECUTE') or has_table_privilege('anon','lp_questions','SELECT') or has_function_privilege('authenticated','lp_ask_question(uuid,uuid,text)','EXECUTE') then raise exception 'FAIL direct privilege';end if;
 end $$;
 rollback;
-select 'PASS: ownership, reservations, payment amount, payment idempotency, chat authorization, transitions, increments, expiry, anti-sniping, auction close, direct permissions' as result;
+select 'PASS: ownership, questions, reservations, payment amount, payment idempotency, chat authorization, transitions, increments, expiry, anti-sniping, auction close, direct permissions' as result;
+


### PR DESCRIPTION
## Especificación vinculada

- **Ficha:** [LP-FEAT-005: Preguntas y respuestas públicas en producto](specs/LP-FEAT-005-preguntas-respuestas-producto.md)
- **Issue:** Closes #13
- **Rama:** `gemini/lp-feat-005-product-qa`

## Resumen del cambio

Implementación de la sección pública de Preguntas y Respuestas (Q&A) en la página de producto:
- **Modelo y base de datos:** Nueva tabla `lp_questions` con RLS estricto, funciones transaccionales `lp_ask_question` y `lp_answer_question`, e índices optimizados para consulta por anuncio y vendedor.
- **Reglas de negocio:**
  - Validación `noBargaining` que detecta y rechaza peticiones de rebaja, ofertas o regateos, protegiendo el principio "El precio no se negocia".
  - Validación `noContact` que bloquea teléfonos, correos y enlaces externos.
  - El vendedor no puede auto-preguntarse en sus propios productos.
  - Solo el vendedor del producto puede publicar respuestas oficiales.
- **Paginación y API:** Endpoint `GET /api/market/questions/:id` con paginación estricta de 10 elementos por página, y endpoints POST para preguntar y responder con límite de tasa anti-spam.
- **Interfaz de usuario:**
  - Componente accesible `ProductQA` integrado en la vista de detalle de artículo.
  - Aviso normativo visible sobre no regateo y no datos de contacto.
  - Formularios con validación en vivo y estados de carga.
  - Sección de respuesta inline para el vendedor.
- **Notificaciones:**
  - Banner en la ficha de producto para el vendedor alertando de preguntas sin responder.
  - Sección y pestaña de **Preguntas** con badge de pendientes en *Mi actividad* (`/my-products`).
  - Historial de consultas realizadas por el comprador con estado de respuesta.
- **Documentación de contexto:** `PROJECT_CONTEXT.md` actualizado trasladando la funcionalidad a características activas y documentando los nuevos endpoints y tablas.

## Evidencia de validación

- `npm run specs:check`: 11 fichas válidas y 22 documentos enlazados.
- `tests/database/marketplace.sql`: `PASS: ownership, questions, reservations, payment amount, payment idempotency, chat authorization, transitions, increments, expiry, anti-sniping, auction close, direct permissions` ejecutado con éxito en PostgreSQL.
- `src/lib/__tests__/rules-qa.test.ts`: 4 pruebas unitarias de dominio aprobadas.
- `src/components/__tests__/ProductQA.test.tsx`: 5 pruebas unitarias de componente aprobadas.
- `npm run build`: Compilación exitosa de producción Next.js 15.5.