### PR TITLE
LP-INFRA-004: crear worktrees dentro del workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ node_modules/
 /blob-report/
 /playwright/.cache/
 
+# Isolated agent worktrees (kept inside the authorized workspace)
+/.worktrees/
+
 .kiro/
 .vercel/
 .next-dev/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,10 +17,22 @@ No implementes una solicitud directamente en `main` o `master`. No cambies de ra
 
 1. Comprueba `git status`, `git worktree list` y las ramas existentes sin alterar cambios.
 2. Actualiza referencias con `git fetch origin`.
-3. Desde el repositorio principal, crea un worktree nuevo basado en `origin/main`: `git worktree add <directorio-aislado> -b <rama> origin/main`.
-4. Usa la rama `<agente>/<id-de-spec-en-minúsculas>-<slug>`, por ejemplo `gemini/lp-feat-004-seo` o `codex/lp-fix-002-login`.
-5. Trabaja, valida, confirma y publica únicamente los archivos de esa spec. No incluyas cambios encontrados en otro worktree.
-6. Abre una pull request hacia `main`. La descripción debe enlazar spec e issue, incluir la evidencia y declarar si `PROJECT_CONTEXT.md` necesitó actualización.
+3. Calcula la raíz principal compartida: `lapela_root=$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")`.
+4. Crea siempre el worktree dentro del workspace autorizado: `git -C "$lapela_root" worktree add "$lapela_root/.worktrees/<id-de-spec-en-minúsculas>" -b <rama> origin/main`.
+5. La ubicación por defecto y canónica es `<raíz-de-la-pela>/.worktrees/<id-de-spec-en-minúsculas>`. No uses una carpeta hermana como `lapela-next-worktrees`; queda fuera del workspace predeterminado de algunos agentes y provoca solicitudes repetidas de permisos.
+6. Usa la rama `<agente>/<id-de-spec-en-minúsculas>-<slug>`, por ejemplo `gemini/lp-feat-004-seo` o `codex/lp-fix-002-login`.
+7. Trabaja, valida, confirma y publica únicamente los archivos de esa spec. No incluyas cambios encontrados en otro worktree.
+8. Abre una pull request hacia `main`. La descripción debe enlazar spec e issue, incluir la evidencia y declarar si `PROJECT_CONTEXT.md` necesitó actualización.
+
+Ejemplo completo desde cualquier worktree existente:
+
+```sh
+lapela_root=$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")
+git -C "$lapela_root" fetch origin
+git -C "$lapela_root" worktree add "$lapela_root/.worktrees/lp-feat-006" -b gemini/lp-feat-006-ejemplo origin/main
+```
+
+Al estar `.worktrees/` bajo la raíz autorizada y en `.gitignore`, el agente mantiene acceso normal sin añadir la copia aislada al repositorio.
 
 Si la rama o el worktree ya existen, reutilízalos tras comprobar que corresponden a la misma spec. Si otro agente los está usando, no escribas en ellos: coordina el relevo o crea un worktree distinto sobre la misma rama solo después de que deje de estar activa.
 

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -298,4 +298,6 @@ La spec continúa siendo la fuente de verdad para requisitos, criterios de acept
 
 `main` contiene únicamente trabajo integrado. Cada spec se implementa en una rama `<agente>/<id-de-spec-en-minúsculas>-<slug>` creada desde `origin/main`, por ejemplo `codex/lp-infra-003-agent-branches`. Cuando hay varios agentes, cada uno usa además un Git worktree diferente; compartir directorio aunque se usen ramas distintas no se considera aislamiento.
 
+La ubicación canónica es `<raíz-de-la-pela>/.worktrees/<id-de-spec-en-minúsculas>`. Está dentro del workspace autorizado para evitar peticiones repetidas de permisos y `/.worktrees/` está excluido en `.gitignore`. No deben crearse nuevos worktrees en la antigua carpeta hermana `lapela-next-worktrees`. Los existentes allí se conservan solamente hasta que termine la tarea asociada y después pueden retirarse con `git worktree remove`.
+
 La entrega se integra mediante pull request. La PR enlaza la spec y la issue, contiene la evidencia de validación e indica si cambió este contexto. El workflow de gobernanza valida el nombre de la rama y que su ID corresponda a una spec registrada. La issue permanece abierta hasta la integración en `main`.

--- a/SPEC_REGISTRY.md
+++ b/SPEC_REGISTRY.md
@@ -55,6 +55,7 @@ Prioridades: `P0` bloquea una operación esencial o implica un riesgo grave; `P1
 | `LP-INFRA-002` | `INFRA` | Trazabilidad de specs mediante GitHub Issues | `VERIFIED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-INFRA-002-github-issues.md) |
 | `LP-FEAT-004` | `FEATURE` | Optimización SEO y rutas semánticas | `VERIFIED` | `P2` | 2026-09-06 | [Abrir ficha](specs/LP-FEAT-004-seo-semantic-urls.md) |
 | `LP-INFRA-003` | `INFRA` | Trabajo aislado por rama para agentes concurrentes | `VERIFIED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-INFRA-003-agent-branches.md) |
+| `LP-INFRA-004` | `INFRA` | Worktrees dentro del workspace autorizado | `IMPLEMENTED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-INFRA-004-worktree-location.md) |
 
 ## Flujo para una solicitud nueva
 

--- a/SPEC_REGISTRY.md
+++ b/SPEC_REGISTRY.md
@@ -55,7 +55,7 @@ Prioridades: `P0` bloquea una operación esencial o implica un riesgo grave; `P1
 | `LP-INFRA-002` | `INFRA` | Trazabilidad de specs mediante GitHub Issues | `VERIFIED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-INFRA-002-github-issues.md) |
 | `LP-FEAT-004` | `FEATURE` | Optimización SEO y rutas semánticas | `VERIFIED` | `P2` | 2026-09-06 | [Abrir ficha](specs/LP-FEAT-004-seo-semantic-urls.md) |
 | `LP-INFRA-003` | `INFRA` | Trabajo aislado por rama para agentes concurrentes | `VERIFIED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-INFRA-003-agent-branches.md) |
-| `LP-INFRA-004` | `INFRA` | Worktrees dentro del workspace autorizado | `IMPLEMENTED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-INFRA-004-worktree-location.md) |
+| `LP-INFRA-004` | `INFRA` | Worktrees dentro del workspace autorizado | `VERIFIED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-INFRA-004-worktree-location.md) |
 
 ## Flujo para una solicitud nueva
 

--- a/specs/LP-INFRA-004-worktree-location.md
+++ b/specs/LP-INFRA-004-worktree-location.md
@@ -1,7 +1,7 @@
 ---
 id: LP-INFRA-004
 type: INFRA
-status: IMPLEMENTED
+status: VERIFIED
 priority: P1
 requested_at: 2026-09-06
 requested_by: usuario
@@ -70,7 +70,7 @@ Los agentes mantienen el aislamiento por rama y directorio, pero crean los nuevo
 - [x] `AC-04` El validador comprueba la ubicación canónica y rechaza la recomendación anterior.
 - [x] `AC-05` Este cambio se realiza en `/Users/jorgeluque/lapela-next/.worktrees/lp-infra-004`.
 - [x] `AC-06` `PROJECT_CONTEXT.md` refleja la nueva ubicación y la excepción temporal de worktrees anteriores.
-- [ ] `AC-07` Specs, rama y workflow superan la validación automática.
+- [x] `AC-07` Specs, rama y workflow superan la validación automática.
 
 ## 7. Experiencia y estados
 
@@ -92,7 +92,7 @@ Los agentes mantienen el aislamiento por rama y directorio, pero crean los nuevo
 | Exclusión | `.worktrees/` no aparece en `git status` | `git check-ignore` confirma la exclusión local; `.gitignore` la hace permanente | 2026-09-06 |
 | Instrucciones | La ubicación antigua no aparece como recomendación | 11 fichas y 22 documentos válidos | 2026-09-06 |
 | Fallo controlado | La ausencia de la ubicación canónica se rechaza | El validador devuelve el error específico esperado | 2026-09-06 |
-| GitHub | Rama, PR e issue quedan enlazadas y validadas | Workflow y enlaces | pendiente |
+| GitHub | Rama, PR e issue quedan enlazadas y validadas | PR `#16`; workflow `validate` correcto | 2026-09-06 |
 
 ## 10. Decisiones, riesgos y preguntas abiertas
 
@@ -105,7 +105,7 @@ Los agentes mantienen el aislamiento por rama y directorio, pero crean los nuevo
 - **Rama:** `codex/lp-infra-004-worktree-location`.
 - **Worktree:** `/Users/jorgeluque/lapela-next/.worktrees/lp-infra-004`.
 - **Issue:** `https://github.com/jorgeluquerubia/lapela/issues/15`.
-- **Pull request:** pendiente.
+- **Pull request:** `https://github.com/jorgeluquerubia/lapela/pull/16`.
 - **Archivos:** `.gitignore`, `AGENTS.md`, `PROJECT_CONTEXT.md` y `tools/validate-specs.mjs`.
 
 ## 12. Historial
@@ -114,3 +114,4 @@ Los agentes mantienen el aislamiento por rama y directorio, pero crean los nuevo
 |---|---|---|---|
 | 2026-09-06 | `IN_PROGRESS` | Corrección registrada e iniciada en la nueva ubicación | Codex |
 | 2026-09-06 | `IMPLEMENTED` | Ubicación, exclusión, instrucciones y control automático incorporados | Codex |
+| 2026-09-06 | `VERIFIED` | Rama y ubicación canónicas aceptadas en GitHub Actions | Codex |

--- a/specs/LP-INFRA-004-worktree-location.md
+++ b/specs/LP-INFRA-004-worktree-location.md
@@ -1,0 +1,116 @@
+---
+id: LP-INFRA-004
+type: INFRA
+status: IMPLEMENTED
+priority: P1
+requested_at: 2026-09-06
+requested_by: usuario
+source: conversación
+owner: producto
+github_issue: https://github.com/jorgeluquerubia/lapela/issues/15
+related_specs: [LP-INFRA-003]
+dependencies: [Git worktree]
+cross_cutting_concerns: [OPS, DOC]
+---
+
+# LP-INFRA-004 · Worktrees dentro del workspace autorizado
+
+## 1. Solicitud original
+
+> Modificar el comportamiento para que la próxima vez el agente cree su worktree sin salir del workspace predeterminado y sin pedir permisos continuamente.
+
+## 2. Contexto y problema
+
+El aislamiento introducido en `LP-INFRA-003` usó `/Users/jorgeluque/lapela-next-worktrees/<spec>`, una carpeta hermana de la raíz autorizada. Gemini siguió ese ejemplo para `LP-FEAT-005`, pero su entorno consideró cada acceso fuera del workspace y solicitó permisos reiteradamente.
+
+## 3. Resultado esperado
+
+Los agentes mantienen el aislamiento por rama y directorio, pero crean los nuevos worktrees bajo `/Users/jorgeluque/lapela-next/.worktrees/<spec-id>`, dentro del workspace autorizado y excluidos del repositorio principal.
+
+## 4. Alcance
+
+### Incluido
+
+- Cambiar la ubicación canónica a `.worktrees/<spec-id>` dentro de la raíz.
+- Ignorar `.worktrees/` en Git.
+- Incluir comandos concretos y comprobaciones en las instrucciones de agentes.
+- Validar automáticamente que `AGENTS.md` conserva la ubicación canónica y no recomienda la carpeta externa anterior.
+- Crear esta mejora desde la nueva ubicación como prueba real.
+
+### Excluido
+
+- Mover `lp-feat-005` mientras su sesión pueda seguir activa.
+- Borrar los worktrees externos existentes.
+- Cambiar el aislamiento por rama, la política de PR o la protección de `main`.
+
+## 5. Requisitos y reglas de negocio
+
+### Requisitos funcionales
+
+- `RF-01`: todo nuevo worktree debe crearse en `<raíz>/.worktrees/<spec-id-en-minúsculas>`.
+- `RF-02`: las instrucciones deben proporcionar el comando de creación desde `origin/main`.
+- `RF-03`: el validador debe detectar si desaparece la ubicación canónica o reaparece como recomendación la carpeta externa.
+
+### Requisitos no funcionales
+
+- `RNF-01`: el worktree debe permanecer dentro del workspace autorizado del agente.
+- `RNF-02`: `.worktrees/` no debe aparecer como contenido versionable ni interferir con búsquedas normales de Git.
+
+### Reglas de negocio
+
+- `RN-01`: cada spec mantiene rama y worktree exclusivos aunque el directorio esté bajo la raíz principal.
+- `RN-02`: no se mueve un worktree que otro agente pueda estar utilizando.
+- `RN-03`: los worktrees antiguos se retiran únicamente después de confirmar que sus tareas terminaron.
+
+## 6. Criterios de aceptación
+
+- [x] `AC-01` `.gitignore` contiene `/.worktrees/`.
+- [x] `AC-02` `AGENTS.md` establece `.worktrees/<spec-id>` como única ubicación por defecto.
+- [x] `AC-03` Las instrucciones explican que la ubicación evita solicitudes por salir del workspace.
+- [x] `AC-04` El validador comprueba la ubicación canónica y rechaza la recomendación anterior.
+- [x] `AC-05` Este cambio se realiza en `/Users/jorgeluque/lapela-next/.worktrees/lp-infra-004`.
+- [x] `AC-06` `PROJECT_CONTEXT.md` refleja la nueva ubicación y la excepción temporal de worktrees anteriores.
+- [ ] `AC-07` Specs, rama y workflow superan la validación automática.
+
+## 7. Experiencia y estados
+
+- El agente crea su directorio aislado sin abandonar la raíz autorizada.
+- La carpeta permanece oculta para Git y no se añade accidentalmente a un commit.
+- La tarea activa conserva el mismo flujo de issue, rama y pull request.
+
+## 8. Datos, API, seguridad y operación
+
+- No afecta a datos, autenticación, API ni producción.
+- `.worktrees/` contiene copias de trabajo completas y debe permanecer ignorada.
+- Los secretos locales continúan excluidos por las reglas existentes de `.env`.
+
+## 9. Plan de validación
+
+| Comprobación | Resultado esperado | Evidencia | Fecha |
+|---|---|---|---|
+| Worktree real | La ruta está dentro de la raíz y usa la rama correcta | `git worktree list` | 2026-09-06 |
+| Exclusión | `.worktrees/` no aparece en `git status` | `git check-ignore` confirma la exclusión local; `.gitignore` la hace permanente | 2026-09-06 |
+| Instrucciones | La ubicación antigua no aparece como recomendación | 11 fichas y 22 documentos válidos | 2026-09-06 |
+| Fallo controlado | La ausencia de la ubicación canónica se rechaza | El validador devuelve el error específico esperado | 2026-09-06 |
+| GitHub | Rama, PR e issue quedan enlazadas y validadas | Workflow y enlaces | pendiente |
+
+## 10. Decisiones, riesgos y preguntas abiertas
+
+- **Decisión:** usar una carpeta oculta dentro de la raíz en vez de ampliar permisos particulares de cada agente.
+- **Riesgo:** herramientas que recorran archivos ignorados podrían entrar en `.worktrees`; Git y los agentes deben limitar búsquedas a archivos versionados o excluirla expresamente.
+- **Preguntas abiertas:** ninguna.
+
+## 11. Implementación y trazabilidad
+
+- **Rama:** `codex/lp-infra-004-worktree-location`.
+- **Worktree:** `/Users/jorgeluque/lapela-next/.worktrees/lp-infra-004`.
+- **Issue:** `https://github.com/jorgeluquerubia/lapela/issues/15`.
+- **Pull request:** pendiente.
+- **Archivos:** `.gitignore`, `AGENTS.md`, `PROJECT_CONTEXT.md` y `tools/validate-specs.mjs`.
+
+## 12. Historial
+
+| Fecha | Estado | Cambio | Autor/agente |
+|---|---|---|---|
+| 2026-09-06 | `IN_PROGRESS` | Corrección registrada e iniciada en la nueva ubicación | Codex |
+| 2026-09-06 | `IMPLEMENTED` | Ubicación, exclusión, instrucciones y control automático incorporados | Codex |

--- a/tools/validate-specs.mjs
+++ b/tools/validate-specs.mjs
@@ -240,6 +240,18 @@ for (const file of markdownFiles) {
   }
 }
 
+const agentsContent = readFileSync(join(root, 'AGENTS.md'), 'utf8');
+const gitignoreContent = readFileSync(join(root, '.gitignore'), 'utf8');
+if (!gitignoreContent.split(/\r?\n/).includes('/.worktrees/')) {
+  fail(`.gitignore: falta la exclusión canónica '/.worktrees/'.`);
+}
+if (!agentsContent.includes('.worktrees/<id-de-spec-en-minúsculas>')) {
+  fail(`AGENTS.md: falta la ubicación canónica de worktrees dentro del workspace.`);
+}
+if (agentsContent.includes('/Users/jorgeluque/lapela-next-worktrees')) {
+  fail(`AGENTS.md: no debe recomendar la antigua carpeta externa 'lapela-next-worktrees'.`);
+}
+
 const changedFromIndex = process.argv.indexOf('--changed-from');
 if (changedFromIndex !== -1) {
   const base = process.argv[changedFromIndex + 1];


### PR DESCRIPTION
## Spec e issue

- **Spec:** [LP-INFRA-004](https://github.com/jorgeluquerubia/lapela/blob/codex/lp-infra-004-worktree-location/specs/LP-INFRA-004-worktree-location.md)
- **Issue:** Closes #15

## Resultado

Los nuevos worktrees se crean bajo `.worktrees/<spec-id>` dentro de la raíz autorizada de La Pela. La carpeta queda ignorada por Git, conserva el aislamiento entre agentes y evita solicitudes reiteradas por acceder a un workspace externo.

## Validación

- [x] Esta tarea se ejecutó desde `/Users/jorgeluque/lapela-next/.worktrees/lp-infra-004`.
- [x] `git check-ignore` confirma que la carpeta no aparece como contenido del proyecto principal.
- [x] El validador acepta la ubicación canónica y rechaza instrucciones que la omitan.
- [x] `npm run specs:check -- --branch-name codex/lp-infra-004-worktree-location` termina con 11 fichas y 22 documentos válidos.

## Contexto transversal

- [x] `PROJECT_CONTEXT.md` documenta la ubicación canónica y el tratamiento temporal de los worktrees externos existentes.
