### PR TITLE
LP-FIX-002: reparar Playwright en CI

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,6 +8,12 @@ jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    env:
+      # Valores sintéticos: permiten arrancar el cliente sin usar secretos ni tocar producción.
+      NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: playwright-anon-key
+      SUPABASE_SERVICE_ROLE_KEY: playwright-service-role-key
+      LAPELA_PAYMENTS_MODE: simulated
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -144,8 +144,8 @@ Servicios externos
 | Pagos | Stripe SDK y Stripe Connect | Preparado para modo real; beta en simulación |
 | Repositorio | GitHub | `github.com/jorgeluquerubia/lapela`, rama principal `main` |
 | Gestión del trabajo | GitHub Issues | Una issue por spec, con etiquetas de tipo, prioridad y estado |
-| CI | GitHub Actions y Playwright | Workflow en `.github/workflows/playwright.yml` |
-| Pruebas | Jest, Testing Library, Playwright y SQL | La cobertura existente incluye pruebas legacy; ver limitaciones de validación |
+| CI | GitHub Actions, validación de specs y Playwright | Los workflows comprueban la trazabilidad documental y el recorrido público principal |
+| Pruebas | Jest, Testing Library, Playwright y SQL | La cobertura existente incluye pruebas legacy; el smoke E2E vigente está aislado de servicios externos |
 
 El proyecto Supabase se llama `lapela-app`. Su referencia es `buzmbigpgsrzjrkzidmr`. Esta referencia y la URL pública no son secretos; las claves y tokens sí lo son.
 
@@ -249,8 +249,8 @@ No hay todavía un panel de administración, alertas centralizadas, métricas de
 
 - `npm run build` es la comprobación fiable actual de compilación, lint y tipos.
 - `tests/database/marketplace.sql` valida propiedad, reservas, importe, idempotencia, chat, transiciones, pujas, expiración, anti-sniping, cierre y privilegios; se ejecutó satisfactoriamente el 2026-09-06.
-- Existen suites Jest y Playwright creadas para la versión anterior. Parte de ellas todavía espera textos, componentes y endpoints legacy, por lo que el conjunto completo no representa fielmente la aplicación reconstruida.
-- El workflow de GitHub ejecuta Playwright en push y pull request, pero debe actualizarse junto con las pruebas E2E antes de tratarlo como puerta de calidad fiable.
+- Existen suites Jest creadas para la versión anterior. Parte de ellas todavía espera textos, componentes y endpoints legacy, por lo que el conjunto completo no representa fielmente la aplicación reconstruida.
+- El workflow de GitHub ejecuta un smoke test Playwright vigente en push y pull request. Usa datos de demostración y valores sintéticos de Supabase, por lo que valida el arranque y la navegación pública sin acceder a producción. Aún no cubre autenticación, persistencia, publicación, compra ni pagos.
 - La producción beta y sus rutas principales se comprobaron mediante build, peticiones HTTP y revisión visual en navegador.
 
 ## 14. Mapa rápido del repositorio

--- a/SPEC_REGISTRY.md
+++ b/SPEC_REGISTRY.md
@@ -56,7 +56,7 @@ Prioridades: `P0` bloquea una operación esencial o implica un riesgo grave; `P1
 | `LP-FEAT-004` | `FEATURE` | Optimización SEO y rutas semánticas | `VERIFIED` | `P2` | 2026-09-06 | [Abrir ficha](specs/LP-FEAT-004-seo-semantic-urls.md) |
 | `LP-INFRA-003` | `INFRA` | Trabajo aislado por rama para agentes concurrentes | `VERIFIED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-INFRA-003-agent-branches.md) |
 | `LP-INFRA-004` | `INFRA` | Worktrees dentro del workspace autorizado | `VERIFIED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-INFRA-004-worktree-location.md) |
-| `LP-FIX-002` | `FIX` | Playwright funcional en pull requests | `IN_PROGRESS` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-FIX-002-playwright-ci.md) |
+| `LP-FIX-002` | `FIX` | Playwright funcional en pull requests | `IMPLEMENTED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-FIX-002-playwright-ci.md) |
 
 ## Flujo para una solicitud nueva
 

--- a/SPEC_REGISTRY.md
+++ b/SPEC_REGISTRY.md
@@ -56,6 +56,7 @@ Prioridades: `P0` bloquea una operación esencial o implica un riesgo grave; `P1
 | `LP-FEAT-004` | `FEATURE` | Optimización SEO y rutas semánticas | `VERIFIED` | `P2` | 2026-09-06 | [Abrir ficha](specs/LP-FEAT-004-seo-semantic-urls.md) |
 | `LP-INFRA-003` | `INFRA` | Trabajo aislado por rama para agentes concurrentes | `VERIFIED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-INFRA-003-agent-branches.md) |
 | `LP-INFRA-004` | `INFRA` | Worktrees dentro del workspace autorizado | `VERIFIED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-INFRA-004-worktree-location.md) |
+| `LP-FIX-002` | `FIX` | Playwright funcional en pull requests | `IN_PROGRESS` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-FIX-002-playwright-ci.md) |
 
 ## Flujo para una solicitud nueva
 

--- a/specs/LP-FIX-002-playwright-ci.md
+++ b/specs/LP-FIX-002-playwright-ci.md
@@ -1,7 +1,7 @@
 ---
 id: LP-FIX-002
 type: FIX
-status: IN_PROGRESS
+status: IMPLEMENTED
 priority: P1
 requested_at: 2026-09-06
 requested_by: usuario
@@ -102,7 +102,7 @@ Las pull requests arrancan la aplicación con una configuración de prueba segur
 
 - **Archivos o módulos:** `.github/workflows/playwright.yml`, `tests/navigation.spec.ts`, `PROJECT_CONTEXT.md`.
 - **Migraciones/configuración:** variables sintéticas en el job de CI.
-- **Commit o despliegue:** pendiente.
+- **Commit o despliegue:** commit `7df1bcb`; PR [#18](https://github.com/jorgeluquerubia/lapela/pull/18).
 - **Notas de implementación:** rama `codex/lp-fix-002-playwright-ci`.
 
 ## 12. Historial
@@ -111,3 +111,4 @@ Las pull requests arrancan la aplicación con una configuración de prueba segur
 |---|---|---|---|
 | 2026-09-06 | `IN_PROGRESS` | Diagnóstico y creación de la ficha | Codex |
 | 2026-09-06 | `IN_PROGRESS` | Configuración sintética y smoke test validados localmente | Codex |
+| 2026-09-06 | `IMPLEMENTED` | PR #18 abierta; validación de GitHub pendiente | Codex |

--- a/specs/LP-FIX-002-playwright-ci.md
+++ b/specs/LP-FIX-002-playwright-ci.md
@@ -1,0 +1,113 @@
+---
+id: LP-FIX-002
+type: FIX
+status: IN_PROGRESS
+priority: P1
+requested_at: 2026-09-06
+requested_by: usuario
+source: conversación
+owner: producto
+github_issue: https://github.com/jorgeluquerubia/lapela/issues/17
+related_specs: []
+dependencies: []
+cross_cutting_concerns: [CI, pruebas E2E, Supabase]
+---
+
+# LP-FIX-002 · Playwright funcional en pull requests
+
+## 1. Solicitud original
+
+> "por cierto la PR que ha creado da errores de playwright, la PR #14"
+
+## 2. Contexto y problema
+
+- **Problema u oportunidad:** el workflow de Playwright intenta iniciar Next.js sin las variables públicas mínimas de Supabase, por lo que el servidor termina antes de ejecutar ninguna prueba.
+- **Personas afectadas:** agentes y responsables que revisan pull requests.
+- **Impacto actual:** la PR #14 y cualquier PR equivalente muestran un fallo E2E que no informa sobre la calidad de la funcionalidad.
+- **Evidencia disponible:** el log del job `test` indica `Missing Supabase URL or Anon Key` y agota los 60 segundos de `webServer`.
+
+## 3. Resultado esperado
+
+Las pull requests arrancan la aplicación con una configuración de prueba segura, ejecutan recorridos E2E representativos de la versión vigente y muestran un resultado útil para decidir si integrar el cambio.
+
+## 4. Alcance
+
+### Incluido
+
+- Proporcionar valores no secretos y exclusivos de prueba para iniciar la aplicación en CI.
+- Sustituir el recorrido legacy por una prueba estable del catálogo y la ficha semántica de un artículo.
+- Actualizar el contexto canónico para reflejar el estado real de Playwright.
+- Aplicar la corrección a la PR #14 después de integrarla en `main`.
+
+### Excluido
+
+- Probar operaciones reales contra Supabase o datos de producción.
+- Cubrir en E2E autenticación, publicación, compra o pagos.
+- Cambiar el comportamiento funcional de LP-FEAT-005.
+
+## 5. Requisitos y reglas de negocio
+
+### Requisitos funcionales
+
+- `RF-01`: El workflow debe iniciar La Pela y ejecutar la navegación desde el catálogo hasta una ficha pública.
+
+### Requisitos no funcionales
+
+- `RNF-01`: La prueba no debe requerir secretos, cuentas ni servicios externos disponibles.
+- `RNF-02`: Un fallo de arranque debe quedar separado de un fallo del recorrido y producir artefactos de Playwright.
+
+### Reglas de negocio
+
+- `RN-01`: La configuración ficticia de CI no puede habilitar pagos reales ni acceder al proyecto Supabase de producción.
+
+## 6. Criterios de aceptación
+
+- [x] `AC-01` Dada una pull request, cuando se ejecuta el workflow, entonces Next.js arranca sin secretos de Supabase.
+- [x] `AC-02` Dado el catálogo de demostración, cuando Playwright abre el inicio y selecciona un artículo, entonces llega a su ruta semántica y muestra la descripción.
+- [ ] `AC-03` El workflow completo de Playwright finaliza correctamente en GitHub Actions.
+- [ ] `AC-04` La PR #14 deja de fallar por esta causa y queda actualizada con `main`.
+
+## 7. Experiencia y estados
+
+- Estados normales: catálogo con datos de demostración y ficha pública.
+- Estados de error o vacío: la prueba controla la respuesta del catálogo para ser determinista.
+- Mensajes y accesibilidad: se usan roles y nombres visibles en las aserciones.
+- Responsive o canales afectados: navegador de escritorio en CI.
+
+## 8. Datos, API, seguridad y operación
+
+- **Datos/modelo:** producto ficticio interceptado en la prueba.
+- **API/integraciones:** el catálogo de demostración evita dependencias de red; Supabase usa una URL y claves sintéticas solo para arrancar.
+- **Autorización y privacidad:** no se emplean credenciales ni datos reales.
+- **Observabilidad y soporte:** informe HTML y trazas de Playwright como artefactos del job.
+- **Métricas o señales de éxito:** job `test` verde en la PR de la corrección y en la PR #14.
+- **Migración/rollback:** revertir el commit de workflow y prueba.
+
+## 9. Plan de validación
+
+| Comprobación | Resultado esperado | Evidencia | Fecha |
+|---|---|---|---|
+| Playwright local con entorno equivalente a CI | Recorrido verde | Chromium: 1 prueba superada en 4,2 s | 2026-09-06 |
+| `npm run specs:check` | Registro coherente | 12 fichas y 23 documentos válidos | 2026-09-06 |
+| GitHub Actions | Jobs `validate` y `test` verdes | Pendiente | 2026-09-06 |
+| PR #14 actualizada | Sin conflicto y Playwright verde | Pendiente | 2026-09-06 |
+
+## 10. Decisiones, riesgos y preguntas abiertas
+
+- **Decisiones:** aislar la E2E de Supabase para probar navegación y no disponibilidad de servicios externos.
+- **Riesgos y límites:** este smoke test no valida persistencia ni permisos de base de datos.
+- **Preguntas abiertas:** ninguna.
+
+## 11. Implementación y trazabilidad
+
+- **Archivos o módulos:** `.github/workflows/playwright.yml`, `tests/navigation.spec.ts`, `PROJECT_CONTEXT.md`.
+- **Migraciones/configuración:** variables sintéticas en el job de CI.
+- **Commit o despliegue:** pendiente.
+- **Notas de implementación:** rama `codex/lp-fix-002-playwright-ci`.
+
+## 12. Historial
+
+| Fecha | Estado | Cambio | Autor/agente |
+|---|---|---|---|
+| 2026-09-06 | `IN_PROGRESS` | Diagnóstico y creación de la ficha | Codex |
+| 2026-09-06 | `IN_PROGRESS` | Configuración sintética y smoke test validados localmente | Codex |

--- a/specs/LP-FIX-002-playwright-ci.md
+++ b/specs/LP-FIX-002-playwright-ci.md
@@ -64,7 +64,7 @@ Las pull requests arrancan la aplicación con una configuración de prueba segur
 
 - [x] `AC-01` Dada una pull request, cuando se ejecuta el workflow, entonces Next.js arranca sin secretos de Supabase.
 - [x] `AC-02` Dado el catálogo de demostración, cuando Playwright abre el inicio y selecciona un artículo, entonces llega a su ruta semántica y muestra la descripción.
-- [ ] `AC-03` El workflow completo de Playwright finaliza correctamente en GitHub Actions.
+- [x] `AC-03` El workflow completo de Playwright finaliza correctamente en GitHub Actions.
 - [ ] `AC-04` La PR #14 deja de fallar por esta causa y queda actualizada con `main`.
 
 ## 7. Experiencia y estados
@@ -89,7 +89,7 @@ Las pull requests arrancan la aplicación con una configuración de prueba segur
 |---|---|---|---|
 | Playwright local con entorno equivalente a CI | Recorrido verde | Chromium: 1 prueba superada en 4,2 s | 2026-09-06 |
 | `npm run specs:check` | Registro coherente | 12 fichas y 23 documentos válidos | 2026-09-06 |
-| GitHub Actions | Jobs `validate` y `test` verdes | Pendiente | 2026-09-06 |
+| GitHub Actions | Jobs `validate` y `test` verdes | PR #18: `validate` en 9 s y `test` en 1 min 40 s | 2026-09-06 |
 | PR #14 actualizada | Sin conflicto y Playwright verde | Pendiente | 2026-09-06 |
 
 ## 10. Decisiones, riesgos y preguntas abiertas
@@ -112,3 +112,4 @@ Las pull requests arrancan la aplicación con una configuración de prueba segur
 | 2026-09-06 | `IN_PROGRESS` | Diagnóstico y creación de la ficha | Codex |
 | 2026-09-06 | `IN_PROGRESS` | Configuración sintética y smoke test validados localmente | Codex |
 | 2026-09-06 | `IMPLEMENTED` | PR #18 abierta; validación de GitHub pendiente | Codex |
+| 2026-09-06 | `IMPLEMENTED` | CI completa verde; pendiente aplicar a PR #14 | Codex |

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -1,32 +1,18 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Navegación de la aplicación', () => {
-  test('el usuario debería poder navegar desde la página de inicio a la página de detalles de un producto', async ({ page }) => {
-    // 1. Ir a la página de inicio y esperar a que la llamada a la API de productos se complete
-    await page.route('**/api/products**', route => route.continue());
-    const responsePromise = page.waitForResponse('**/api/products**');
-    await page.goto('/');
-    await responsePromise;
+  test('permite pasar del catálogo de ejemplo a la ficha semántica de un artículo', async ({ page }) => {
+    await page.goto('/?examples=1');
 
-    // 2. Esperar a que los productos se carguen y encontrar el primer producto
-    // Usamos un selector que apunte a la tarjeta de producto
-    const firstProductCard = page.locator('.product-card').first();
-    await expect(firstProductCard).toBeVisible();
+    await expect(page.getByText('Catálogo de ejemplo')).toBeVisible();
+    const product = page.getByRole('link', {name: 'Auriculares inalámbricos negros', exact: true});
+    await expect(product).toBeVisible();
 
-    // Obtener el enlace del producto para la verificación posterior
-    const productLinkElement = firstProductCard.locator('a').first();
-    const productLink = await productLinkElement.getAttribute('href');
-    expect(productLink).not.toBeNull();
+    await product.click();
 
-    // 3. Hacer clic en el título del producto, que es un enlace
-    await firstProductCard.locator('h3').click();
-
-    // 4. Verificar que la URL ha cambiado a la página de detalles del producto
-    await page.waitForURL(`**${productLink}`);
-    expect(page.url()).toContain(productLink!);
-
-    // 5. Verificar que algún contenido de la página de detalles es visible
-    // Por ejemplo, buscamos el título "Descripción" que debería estar en la página de detalles.
-    await expect(page.getByRole('heading', { name: 'Descripción' })).toBeVisible();
+    await expect(page).toHaveURL(/\/articulos\/ejemplo-auriculares-inalambricos-negros-demo-1$/);
+    await expect(page.getByRole('heading', {name: 'Auriculares inalámbricos negros'})).toBeVisible();
+    await expect(page.getByRole('heading', {name: 'Todo sobre este artículo'})).toBeVisible();
+    await expect(page.getByText('Anuncio de ejemplo · Fotografía ilustrativa. Este artículo no está a la venta.', {exact: true})).toBeVisible();
   });
 });


### PR DESCRIPTION
La PR #14 no puede ejecutar sus pruebas porque Next.js termina al no recibir la configuración pública mínima de Supabase. Este cambio añade valores sintéticos y seguros al job y reemplaza la navegación legacy por un smoke test determinista del catálogo de ejemplo a la ficha semántica.

Spec: `specs/LP-FIX-002-playwright-ci.md`
Issue: Closes #17

Validación local:
- `npm run specs:check`: 12 fichas y 23 documentos válidos.
- Playwright Chromium: recorrido catálogo → ficha superado.

`PROJECT_CONTEXT.md` se actualiza porque Playwright pasa de figurar como workflow no fiable a documentar su cobertura real y sus límites.
