### PR TITLE
[LP-FEAT-007] Chat en reserva y confirmación de cobro en persona por el vendedor

### DIFF
--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -70,6 +70,7 @@ La propuesta combina la sencillez de uso de un marketplace móvil con dos mecani
 - Reserva temporal de 48 horas mientras el pago está pendiente (actualizado desde los 31 minutos iniciales).
 - Política de compras pública y canónica en `/politica-de-compras` enlazada desde el diálogo de confirmación y el pie de página.
 - En beta, confirmación explícita de un pago simulado sin cargo.
+- Confirmación de cobro en persona por parte del vendedor (`pay-in-person`), marcando el pedido como completado (`completed`, `payment_mode = 'in_person'`) y el artículo como vendido (`sold`).
 - Envío con información de seguimiento o coordinación de recogida.
 - Confirmación de recepción por el comprador.
 - Estados del modelo de pedido: `pending_payment`, `paid`, `shipped`, `completed`, `cancelled`, `refunded` y `disputed`. Las acciones de usuario actuales cubren pago, envío y recepción; disputa y reembolso todavía requieren operación futura.
@@ -86,7 +87,7 @@ La propuesta combina la sencillez de uso de un marketplace móvil con dos mecani
 
 ### Conversación y confianza
 
-- Chat privado solo para comprador y vendedor de un pedido en estado pagado o posterior.
+- Chat privado exclusivo para comprador y vendedor de un pedido activo: se abre desde el momento de la reserva (`pending_payment`) para acordar el método de pago (en persona o por plataforma) y la entrega, manteniéndose durante los estados pagados y posteriores.
 - Límite de veinte mensajes por minuto y usuario.
 - Preguntas y respuestas públicas en la ficha de producto con paginación de 10 elementos, aviso anti-regateo, bloqueo de datos de contacto y notificaciones de preguntas pendientes para el vendedor.
 - Seguimiento de compras, ventas, pujas y anuncios en `Mi actividad`.
@@ -209,9 +210,10 @@ Las claves secretas no deben usar el prefijo `NEXT_PUBLIC_`, aparecer en specs, 
 - `lp_close_auctions`: cierra subastas y adjudica al mejor postor.
 - `lp_confirm_payment`: valida evento, sesión, importe e idempotencia de Stripe.
 - `lp_simulate_payment`: confirma únicamente pedidos sandbox del comprador.
+- `lp_confirm_in_person_payment`: permite al vendedor confirmar el cobro recibido en persona, completando el pedido y vendiendo el artículo.
 - `lp_transition`: controla envío y recepción según actor y estado.
 - `lp_release`: cancela reservas caducadas y libera el anuncio.
-- `lp_send_message`: autoriza chat solo entre las partes después del pago.
+- `lp_send_message`: autoriza chat solo entre las partes durante la reserva o tras el pago.
 - `lp_ask_question`: valida y registra una pregunta pública impidiendo la auto-pregunta del vendedor.
 - `lp_answer_question`: autoriza únicamente al vendedor para publicar la respuesta oficial.
 
@@ -235,7 +237,8 @@ El bucket `product-images` es público porque contiene fotografías de anuncios.
 | `POST /api/market/answer/:id` | Vendedor del artículo | Responder públicamente a una pregunta |
 | `POST /api/market/checkout/:id` | Comprador | Reservar o continuar un pago |
 | `POST /api/market/simulate-payment/:id` | Comprador, sandbox | Confirmar pago simulado |
-| `POST /api/market/message/:id` | Partes, pedido pagado | Enviar mensaje sobre la entrega |
+| `POST /api/market/pay-in-person/:id` | Vendedor | Confirmar cobro en persona y completar pedido |
+| `POST /api/market/message/:id` | Partes, pedido en reserva o pagado | Enviar mensaje sobre la entrega o pago |
 | `POST /api/market/ship/:id` | Vendedor | Marcar envío o entrega preparada |
 | `POST /api/market/complete/:id` | Comprador | Confirmar recepción |
 | `POST /api/market/withdraw/:id` | Vendedor | Retirar anuncio disponible sin pujas |

--- a/SPEC_REGISTRY.md
+++ b/SPEC_REGISTRY.md
@@ -59,6 +59,7 @@ Prioridades: `P0` bloquea una operación esencial o implica un riesgo grave; `P1
 | `LP-FIX-002` | `FIX` | Playwright funcional en pull requests | `VERIFIED` | `P1` | 2026-09-06 | [Abrir ficha](specs/LP-FIX-002-playwright-ci.md) |
 | `LP-FEAT-005` | `FEATURE` | Preguntas y respuestas públicas en producto | `VERIFIED` | `P2` | 2026-09-06 | [Abrir ficha](specs/LP-FEAT-005-preguntas-respuestas-producto.md) |
 | `LP-FEAT-006` | `FEATURE` | Confirmación de compra, reserva de 48h y política de compras | `VERIFIED` | `P1` | 2026-09-09 | [Abrir ficha](specs/LP-FEAT-006-confirmacion-reserva-politica-compras.md) |
+| `LP-FEAT-007` | `FEATURE` | Chat en reserva y confirmación de cobro en persona por el vendedor | `VERIFIED` | `P1` | 2026-09-09 | [Abrir ficha](specs/LP-FEAT-007-chat-reserva-cobro-en-persona.md) |
 
 
 ## Flujo para una solicitud nueva

--- a/specs/LP-FEAT-007-chat-reserva-cobro-en-persona.md
+++ b/specs/LP-FEAT-007-chat-reserva-cobro-en-persona.md
@@ -1,0 +1,139 @@
+---
+id: LP-FEAT-007
+type: FEATURE
+status: VERIFIED
+priority: P1
+requested_at: 2026-09-09
+requested_by: usuario
+source: conversación
+owner: producto
+github_issue: https://github.com/jorgeluquerubia/lapela/issues/21
+related_specs: [LP-FEAT-001, LP-FEAT-002, LP-FEAT-006]
+dependencies: []
+cross_cutting_concerns: []
+---
+
+# LP-FEAT-007 · Chat en reserva y confirmación de cobro en persona por el vendedor
+
+## 1. Solicitud original
+
+> El chat entre comprador y vendedor deberia abrirse una vez el artículo ya está reservado, ya que deben ponerse de acuerdo de cómo va a ser el pago, en persona, a través de la plataforma , con envío, en persona, etc. Como el pago puede ser en persona el vendedor debe poder tener una opción de pago recibido , para poder finalizar el ciclo de vida del articulo y darlo por vendido. (Pasaría de reservado a vendido y dejaría de estar disponible)
+
+## 2. Contexto y problema
+
+- **Problema u oportunidad:** Con la regla anterior, el chat privado del pedido solo se habilitaba una vez confirmado el pago vía Stripe o simulación (`paid`). Esto impedía que comprador y vendedor se comunicasen tras la reserva para acordar si pagarían en mano, el punto de encuentro físico o el método de entrega. Asimismo, no existía mecanismo para que el vendedor confirmase que había recibido el cobro en efectivo/en mano, imposibilitando completar pedidos fuera de la pasarela online.
+- **Personas afectadas:** Compradores y vendedores que eligen entrega en mano o pago en persona tras reservar el producto.
+- **Impacto actual:** Imposibilidad de coordinar la transacción durante el periodo de reserva de 48 horas y bloqueo del ciclo de vida del producto cuando el pago no es online.
+- **Evidencia disponible:** Solicitud explícita del usuario y restricciones en `lp_send_message`, `canMessage` y `src/app/orders/[id]/page.tsx`.
+
+## 3. Resultado esperado
+
+- El chat del pedido se habilita de inmediato una vez creado el pedido en estado reservado (`pending_payment`), permitiendo el diálogo exclusivo entre comprador y vendedor para coordinar el pago (en persona o por plataforma) y la entrega.
+- El vendedor dispone de un botón y flujo de confirmación explícito para marcar el pago como recibido en persona.
+- Al confirmar el cobro en persona, el pedido pasa a estado `completed` con modo de pago `in_person` y el artículo pasa a estado `sold`, finalizando su ciclo de vida y quedando no disponible para otros usuarios.
+
+## 4. Alcance
+
+### Incluido
+
+- Actualización de la regla de mensajería `canMessage` para incluir pedidos en estado `pending_payment`.
+- Modificación de la función de base de datos `lp_send_message` para autorizar el envío en `pending_payment`.
+- Creación de la función SQL transaccional `lp_confirm_in_person_payment(p_order uuid, p_actor uuid)` en PostgreSQL.
+- Actualización de la restricción de comprobación `lp_orders_payment_mode_check` para admitir el valor `'in_person'`.
+- Endpoint `POST /api/market/pay-in-person/:id` en `src/controllers/marketplace.ts`.
+- Interfaz en `/orders/[id]`:
+  - Activación del chat durante la reserva con texto explicativo para coordinar pago y entrega.
+  - Sección para el vendedor con botón "Marcar pago recibido en persona" y diálogo de confirmación interactivo.
+  - Visualización del estado final completado con aviso de pago en persona.
+
+### Excluido
+
+- Modificación de los flujos de disputa o cancelaciones automáticas tras 48h (que continúan gestionados por `maintain()` / `lp_release()`).
+
+## 5. Requisitos y reglas de negocio
+
+### Requisitos funcionales
+
+- `RF-01`: Una vez reservado el artículo (`pending_payment`), tanto el comprador como el vendedor pueden enviar y recibir mensajes en el chat del pedido.
+- `RF-02`: Los usuarios no participantes en el pedido no pueden leer ni enviar mensajes en el chat de la reserva.
+- `RF-03`: El vendedor dispone en la pantalla del pedido de la acción de confirmar el cobro en persona mientras el pedido permanezca en `pending_payment`.
+- `RF-04`: Al confirmar el pago en persona, el pedido se actualiza a `completed` con `payment_mode = 'in_person'` y el anuncio se marca como `sold`.
+- `RF-05`: Un comprador no puede ejecutar la acción de confirmar cobro en persona.
+
+### Requisitos no funcionales
+
+- `RNF-01`: La confirmación de cobro en persona debe ser atómica e idempotente en PostgreSQL mediante `lp_confirm_in_person_payment`.
+- `RNF-02`: El chat debe actualizarse reactivamente o mediante sondeo periódico como en el resto de estados del pedido.
+
+### Reglas de negocio
+
+- `RN-01`: El chat solo está disponible entre el comprador y el vendedor del pedido específico.
+- `RN-02`: Solo el vendedor asignado al pedido puede dar fe de la recepción del dinero en mano.
+- `RN-03`: Una vez confirmado el pago en persona, el artículo no puede volver a estar disponible ni reservarse por otro usuario.
+
+## 6. Criterios de aceptación
+
+- [x] `AC-01` Dado un pedido en estado `pending_payment`, cuando el comprador o el vendedor acceden a `/orders/[id]`, entonces el chat de mensajes está habilitado y permite enviar mensajes.
+- [x] `AC-02` Dado un usuario ajeno al pedido, cuando intenta enviar un mensaje a dicho pedido reservado mediante `lp_send_message` o API, entonces la operación es denegada con error de autorización.
+- [x] `AC-03` Dado un pedido en estado `pending_payment`, cuando el vendedor pulsa en "Marcar pago recibido en persona" y confirma la acción, entonces el pedido pasa a `completed`, el modo de pago se guarda como `in_person` y el artículo pasa a `sold`.
+- [x] `AC-04` Dado un comprador en un pedido en estado `pending_payment`, cuando accede al pedido, entonces no se le muestra el botón de confirmar cobro en persona y no puede ejecutar la acción vía API.
+
+## 7. Experiencia y estados
+
+- Pantalla de pedido (`/orders/[id]`):
+  - Estado `pending_payment`: aviso de reserva activa y chat abierto con indicación: "Coordina el método de pago (en persona o por la plataforma) y los detalles de la entrega".
+  - Vista vendedor: botón secundario/primario "Marcar pago recibido en persona" con panel de confirmación ("¿Has cobrado el importe en mano?").
+  - Pedido completado por cobro en persona: banner "Pago en persona recibido · Venta finalizada" y artículo reflejado como vendido.
+
+## 8. Datos, API, seguridad y operación
+
+- Base de datos:
+  - Migración `supabase/migrations/202609090002_chat_on_reservation_and_in_person_pay.sql`.
+  - Actualización de `lp_orders.payment_mode` para incluir `'in_person'`.
+  - Nueva función `lp_confirm_in_person_payment(uuid, uuid)`.
+  - Actualización de `lp_send_message(uuid, uuid, text)`.
+- API:
+  - Ruta POST `api/market/pay-in-person/[id]` (o `action==='pay-in-person'`).
+
+## 9. Plan de validación
+
+| Comprobación | Resultado esperado | Evidencia | Fecha |
+|---|---|---|---|
+| Invariante SQL de chat en reserva | Comprador y vendedor envían mensajes en `pending_payment`; ajenos bloqueados | Migración `202609090002` aplicada; `tests/database/marketplace.sql` ejecutado con éxito en Supabase | 2026-09-09 |
+| Invariante SQL de cobro en persona | Vendedor confirma cobro en persona; pedido `completed`, listing `sold` | Verificado en `tests/database/marketplace.sql` (bloqueo a comprador y terceros, pedido `completed`, listing `sold`) | 2026-09-09 |
+| Pruebas unitarias de reglas | `canMessage` devuelve true para `pending_payment` | `src/lib/__tests__/rules-order-chat.test.ts` (4/4 pruebas superadas) | 2026-09-09 |
+| Pruebas de componente Order | Chat accesible y botón de confirmación para vendedor | `src/app/orders/[id]/__tests__/Order.test.tsx` (2/2 pruebas superadas) | 2026-09-09 |
+| `npm run specs:check` | Ficha registrada y gobernanza documental correcta | 15 fichas registradas y 26 documentos enlazados | 2026-09-09 |
+| `npm run build` | Compilación sin errores | 26 rutas compiladas con éxito en Next.js 15.5 | 2026-09-09 |
+
+## 10. Decisiones, riesgos y preguntas abiertas
+
+- **Decisiones:**
+  - El pago en persona transiciona el pedido directamente a `completed`, ya que la entrega y el cobro se realizan simultáneamente en el encuentro físico.
+  - Se amplía el enum check de `payment_mode` con `'in_person'`.
+- **Riesgos y límites:**
+  - Transacciones fuera de plataforma: la plataforma advierte de que el pago en persona se realiza bajo responsabilidad mutua de las partes y finaliza la responsabilidad de intermediación al confirmarse por el vendedor.
+
+## 11. Implementación y trazabilidad
+
+- **Archivos o módulos:**
+  - `specs/LP-FEAT-007-chat-reserva-cobro-en-persona.md`
+  - `SPEC_REGISTRY.md`
+  - `PROJECT_CONTEXT.md`
+  - `supabase/migrations/202609090002_chat_on_reservation_and_in_person_pay.sql`
+  - `tests/database/marketplace.sql`
+  - `src/lib/rules.ts`
+  - `src/controllers/marketplace.ts`
+  - `src/app/orders/[id]/page.tsx`
+  - `src/lib/__tests__/rules-order-chat.test.ts`
+  - `src/app/orders/[id]/__tests__/Order.test.tsx`
+- **Migraciones/configuración:** `202609090002_chat_on_reservation_and_in_person_pay.sql` aplicada en Supabase
+- **Commit o despliegue:** Rama `gemini/lp-feat-007-chat-reserva-cobro-en-persona`
+- **Notas de implementación:** Rama `gemini/lp-feat-007-chat-reserva-cobro-en-persona`.
+
+## 12. Historial
+
+| Fecha | Estado | Cambio | Autor/agente |
+|---|---|---|---|
+| 2026-09-09 | `IN_PROGRESS` | Creación de especificación e inicio de implementación | Gemini |
+| 2026-09-09 | `VERIFIED` | Implementación completa, migraciones remotas aplicadas y suites de pruebas superadas | Gemini |

--- a/src/app/orders/[id]/__tests__/Order.test.tsx
+++ b/src/app/orders/[id]/__tests__/Order.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import Order from '../page';
+import * as apiModule from '@/lib/api';
+
+jest.mock('next/navigation', () => ({
+  useParams: () => ({ id: 'order-uuid-1234' }),
+}));
+
+jest.mock('next/link', () => {
+  return ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  );
+});
+
+jest.mock('@/lib/api', () => ({
+  api: jest.fn(),
+}));
+
+describe('Order page - Chat in reservation & in-person payment (LP-FEAT-007)', () => {
+  const buyerId = 'buyer-uuid-1111';
+  const sellerId = 'seller-uuid-2222';
+
+  const baseOrder = {
+    id: 'order-uuid-1234',
+    buyer_id: buyerId,
+    seller_id: sellerId,
+    amount_cents: 5000,
+    status: 'pending_payment',
+    expires_at: new Date(Date.now() + 48 * 3600 * 1000).toISOString(),
+    payment_mode: null,
+    tracking: null,
+    shipping_address: null,
+    listing: {
+      id: 'listing-uuid-5678',
+      title: 'Cámara réflex profesional',
+      images: ['https://example.com/camera.jpg'],
+      delivery: 'pickup',
+      location: 'Madrid',
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders chat and in-person payment confirmation option for the seller during pending_payment', async () => {
+    (apiModule.api as jest.Mock).mockImplementation((path: string) => {
+      if (path === 'order/order-uuid-1234') {
+        return Promise.resolve({
+          order: baseOrder,
+          messages: [
+            { id: 'msg-1', sender_id: buyerId, content: 'Hola, ¿podemos quedar en Sol?', created_at: new Date().toISOString() },
+          ],
+          userId: sellerId,
+          simulated: false,
+          canMessage: true,
+        });
+      }
+      if (path === 'pay-in-person/order-uuid-1234') {
+        return Promise.resolve({ success: true });
+      }
+      return Promise.resolve({});
+    });
+
+    render(<Order />);
+
+    // Wait for order to load
+    await waitFor(() => {
+      expect(screen.getByText('Pendiente de pago')).toBeInTheDocument();
+    });
+
+    // Chat is enabled and shows messages
+    expect(screen.getByText('Hola, ¿podemos quedar en Sol?')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Mensaje sobre la entrega o pago/i)).toBeInTheDocument();
+
+    // Seller sees button to mark payment received in person
+    const inPersonBtn = screen.getByRole('button', { name: /Marcar pago recibido en persona/i });
+    expect(inPersonBtn).toBeInTheDocument();
+
+    // Click it to open confirmation
+    fireEvent.click(inPersonBtn);
+    expect(screen.getByText(/¿Confirmas que has cobrado los/i)).toBeInTheDocument();
+    const confirmBtn = screen.getByRole('button', { name: /Sí, marcar como cobrado y vendido/i });
+    expect(confirmBtn).toBeInTheDocument();
+
+    // Confirm in person payment
+    fireEvent.click(confirmBtn);
+    await waitFor(() => {
+      expect(apiModule.api).toHaveBeenCalledWith('pay-in-person/order-uuid-1234', expect.anything());
+    });
+  });
+
+  it('renders chat for buyer during pending_payment without in-person payment button', async () => {
+    (apiModule.api as jest.Mock).mockResolvedValue({
+      order: baseOrder,
+      messages: [],
+      userId: buyerId,
+      simulated: false,
+      canMessage: true,
+    });
+
+    render(<Order />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Pendiente de pago')).toBeInTheDocument();
+    });
+
+    // Chat is open
+    expect(screen.getByText('Ya podéis hablar.')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Mensaje sobre la entrega o pago/i)).toBeInTheDocument();
+
+    // Buyer should NOT see seller's in-person payment button
+    expect(screen.queryByRole('button', { name: /Marcar pago recibido en persona/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/app/orders/[id]/page.tsx
+++ b/src/app/orders/[id]/page.tsx
@@ -4,6 +4,193 @@ import Link from 'next/link';
 import {useEffect,useState,useCallback} from 'react';
 import {api} from '@/lib/api';
 import {money} from '@/lib/rules';
-export default function Order(){const {id}=useParams<{id:string}>();const [data,setData]=useState<any>(null);const [error,setError]=useState('');const [content,setContent]=useState('');const [tracking,setTracking]=useState('');const [busy,setBusy]=useState(false);const [confirmPayment,setConfirmPayment]=useState(false);const load=useCallback(()=>api('order/'+id).then(setData).catch(e=>setError(e.message)),[id]);useEffect(()=>{load();const timer=setInterval(load,10000);return()=>clearInterval(timer)},[load]);async function action(kind:string){setBusy(true);setError('');try{const r=await api(kind+'/'+id,kind==='message'?{content}:kind==='checkout'?{order:true}:{tracking});if(r.url){window.location.assign(r.url);return}setConfirmPayment(false);setContent('');await load()}catch(e){setError((e as Error).message)}finally{setBusy(false)}}
-if(!data)return <div className="empty-state"><h1>{error?'No se pudo abrir el pedido':'Cargando pedido…'}</h1><p>{error}</p><Link href="/my-products" className="button">Mi actividad</Link></div>;const o=data.order;const buyer=data.userId===o.buyer_id;const labels:Record<string,string>={pending_payment:'Pendiente de pago',paid:'Pago confirmado',shipped:'Enviado',completed:'Entrega completada',cancelled:'Cancelado',disputed:'En revisión',refunded:'Reembolsado'};
-return <><div className="breadcrumbs"><Link href="/my-products">Mi actividad</Link><span>/</span><span>Pedido {id.slice(0,8)}</span></div><h1>{labels[o.status]||o.status}</h1>{(data.simulated||o.payment_mode==='simulation')&&<div className="notice">Pedido de prueba · Pago simulado, sin cargo real.</div>}{error&&<p className="error-message" role="alert">{error}</p>}<div className="order-layout"><section className="order-summary"><img src={o.listing.images[0]} alt={o.listing.title}/><h2>{o.listing.title}</h2><p className="detail-price">{money(o.amount_cents)}</p><p>{o.listing.delivery==='pickup'?'Recogida en '+o.listing.location:'Envío incluido en el total'}</p>{o.status==='pending_payment'&&<><div className="notice">El pago está pendiente. Si acabas de pagar, esta página se actualizará cuando llegue la confirmación.</div>{buyer&&<button className="button primary" disabled={busy} onClick={()=>data.simulated?setConfirmPayment(true):action('checkout')}>{data.simulated?'Simular pago':'Continuar al pago'}</button>}{confirmPayment&&<div className="confirmation"><strong>Confirmar pago simulado de {money(o.amount_cents)}</strong><p>No se realizará ningún cargo. Se habilitará el chat de este pedido de prueba.</p><button className="button primary" disabled={busy} onClick={()=>action('simulate-payment')}>Confirmar simulación</button><button className="button" onClick={()=>setConfirmPayment(false)}>Volver</button></div>}<p className="muted">Reserva hasta {new Date(o.expires_at).toLocaleString('es-ES')}.</p></>}{!buyer&&o.status==='paid'&&<form onSubmit={e=>{e.preventDefault();action('ship')}}><label>{o.listing.delivery==='shipping'?'Transportista y seguimiento':'Detalle de entrega'}<input className="field-input" value={tracking} onChange={e=>setTracking(e.target.value)} maxLength={200} required={o.listing.delivery==='shipping'}/></label><button className="button primary" disabled={busy}>Marcar {o.listing.delivery==='shipping'?'como enviado':'entrega preparada'}</button></form>}{buyer&&['paid','shipped'].includes(o.status)&&<button className="button primary" disabled={busy} onClick={()=>{if(window.confirm('¿Confirmas que has recibido el artículo y has revisado su estado?'))action('complete')}}>Confirmar recepción</button>}{o.tracking&&<p className="notice">Seguimiento: {o.tracking}</p>}{o.shipping_address&&<div><h3>Dirección de envío</h3><p>{o.shipping_address.name}<br/>{o.shipping_address.address?.line1}<br/>{o.shipping_address.address?.line2}<br/>{o.shipping_address.address?.postal_code} {o.shipping_address.address?.city}</p></div>}</section><section className="order-chat"><h2>Concretar la entrega</h2>{data.canMessage?<><p className="muted">Conversación privada entre comprador y vendedor. El precio ya está acordado.</p><div className="message-list" aria-live="polite">{!data.messages.length&&<div className="empty-state"><h3>Ya podéis hablar.</h3><p>Coordina el envío, el lugar o la hora de recogida.</p></div>}{data.messages.map((m:any)=><div key={m.id} className={'message '+(m.sender_id===data.userId?'own':'')}><strong>{m.sender_id===data.userId?'Tú':buyer?'Vendedor':'Comprador'}</strong><p>{m.content}</p><small>{new Date(m.created_at).toLocaleString('es-ES')}</small></div>)}</div><form onSubmit={e=>{e.preventDefault();action('message')}}><label htmlFor="message">Mensaje sobre la entrega</label><textarea className="field-input" id="message" value={content} onChange={e=>setContent(e.target.value)} maxLength={2000} required rows={3}/><button className="button primary" disabled={busy||!content.trim()}>Enviar mensaje</button></form></>:<div className="empty-state"><h3>El chat todavía está cerrado.</h3><p>Se habilitará cuando el proveedor confirme el pago. Una reserva no abre la conversación.</p></div>}</section></div></>}
+
+export default function Order(){
+  const {id}=useParams<{id:string}>();
+  const [data,setData]=useState<any>(null);
+  const [error,setError]=useState('');
+  const [content,setContent]=useState('');
+  const [tracking,setTracking]=useState('');
+  const [busy,setBusy]=useState(false);
+  const [confirmPayment,setConfirmPayment]=useState(false);
+  const [confirmInPerson,setConfirmInPerson]=useState(false);
+
+  const load=useCallback(()=>api('order/'+id).then(setData).catch(e=>setError(e.message)),[id]);
+
+  useEffect(()=>{
+    load();
+    const timer=setInterval(load,10000);
+    return()=>clearInterval(timer);
+  },[load]);
+
+  async function action(kind:string){
+    setBusy(true);
+    setError('');
+    try{
+      const r=await api(kind+'/'+id,kind==='message'?{content}:kind==='checkout'?{order:true}:{tracking});
+      if(r.url){
+        window.location.assign(r.url);
+        return;
+      }
+      setConfirmPayment(false);
+      setConfirmInPerson(false);
+      setContent('');
+      await load();
+    }catch(e){
+      setError((e as Error).message);
+    }finally{
+      setBusy(false);
+    }
+  }
+
+  if(!data)return (
+    <div className="empty-state">
+      <h1>{error?'No se pudo abrir el pedido':'Cargando pedido…'}</h1>
+      <p>{error}</p>
+      <Link href="/my-products" className="button">Mi actividad</Link>
+    </div>
+  );
+
+  const o=data.order;
+  const buyer=data.userId===o.buyer_id;
+  const labels:Record<string,string>={
+    pending_payment:'Pendiente de pago',
+    paid:'Pago confirmado',
+    shipped:'Enviado',
+    completed:'Entrega completada',
+    cancelled:'Cancelado',
+    disputed:'En revisión',
+    refunded:'Reembolsado'
+  };
+
+  return (
+    <>
+      <div className="breadcrumbs">
+        <Link href="/my-products">Mi actividad</Link>
+        <span>/</span>
+        <span>Pedido {id.slice(0,8)}</span>
+      </div>
+      <h1>{labels[o.status]||o.status}</h1>
+      {(data.simulated||o.payment_mode==='simulation')&&(
+        <div className="notice">Pedido de prueba · Pago simulado, sin cargo real.</div>
+      )}
+      {o.payment_mode==='in_person'&&(
+        <div className="notice">Pago en persona registrado · Venta finalizada directamente entre las partes.</div>
+      )}
+      {error&&<p className="error-message" role="alert">{error}</p>}
+      <div className="order-layout">
+        <section className="order-summary">
+          <img src={o.listing.images[0]} alt={o.listing.title}/>
+          <h2>{o.listing.title}</h2>
+          <p className="detail-price">{money(o.amount_cents)}</p>
+          <p>{o.listing.delivery==='pickup'?'Recogida en '+o.listing.location:'Envío incluido en el total'}</p>
+          
+          {o.status==='pending_payment'&&(
+            <>
+              <div className="notice">
+                Artículo reservado. Utilizad el chat para acordar si el pago se realizará en mano/en persona o a través de la plataforma, así como los detalles de entrega.
+              </div>
+              {buyer&&(
+                <button className="button primary" disabled={busy} onClick={()=>data.simulated?setConfirmPayment(true):action('checkout')}>
+                  {data.simulated?'Simular pago por plataforma':'Pagar con tarjeta'}
+                </button>
+              )}
+              {confirmPayment&&(
+                <div className="confirmation">
+                  <strong>Confirmar pago simulado de {money(o.amount_cents)}</strong>
+                  <p>No se realizará ningún cargo. Se registrará el pedido como pagado.</p>
+                  <button className="button primary" disabled={busy} onClick={()=>action('simulate-payment')}>Confirmar simulación</button>
+                  <button className="button" onClick={()=>setConfirmPayment(false)}>Volver</button>
+                </div>
+              )}
+              {!buyer&&!confirmInPerson&&(
+                <div style={{marginTop:'1rem'}}>
+                  <button className="button primary" disabled={busy} onClick={()=>setConfirmInPerson(true)}>
+                    Marcar pago recibido en persona
+                  </button>
+                </div>
+              )}
+              {!buyer&&confirmInPerson&&(
+                <div className="confirmation" style={{marginTop:'1rem'}}>
+                  <strong>Confirmar cobro en persona</strong>
+                  <p>¿Confirmas que has cobrado los {money(o.amount_cents)} en mano? El pedido se dará por completado y el artículo quedará vendido.</p>
+                  <button className="button primary" disabled={busy} onClick={()=>action('pay-in-person')}>
+                    Sí, marcar como cobrado y vendido
+                  </button>
+                  <button className="button" onClick={()=>setConfirmInPerson(false)}>Cancelar</button>
+                </div>
+              )}
+              <p className="muted">Reserva activa hasta {new Date(o.expires_at).toLocaleString('es-ES')}.</p>
+            </>
+          )}
+
+          {!buyer&&o.status==='paid'&&(
+            <form onSubmit={e=>{e.preventDefault();action('ship')}}>
+              <label>
+                {o.listing.delivery==='shipping'?'Transportista y seguimiento':'Detalle de entrega'}
+                <input className="field-input" value={tracking} onChange={e=>setTracking(e.target.value)} maxLength={200} required={o.listing.delivery==='shipping'}/>
+              </label>
+              <button className="button primary" disabled={busy}>
+                Marcar {o.listing.delivery==='shipping'?'como enviado':'entrega preparada'}
+              </button>
+            </form>
+          )}
+
+          {buyer&&['paid','shipped'].includes(o.status)&&(
+            <button className="button primary" disabled={busy} onClick={()=>{if(window.confirm('¿Confirmas que has recibido el artículo y has revisado su estado?'))action('complete')}}>
+              Confirmar recepción
+            </button>
+          )}
+
+          {o.tracking&&<p className="notice">Seguimiento: {o.tracking}</p>}
+          {o.shipping_address&&(
+            <div>
+              <h3>Dirección de envío</h3>
+              <p>
+                {o.shipping_address.name}<br/>
+                {o.shipping_address.address?.line1}<br/>
+                {o.shipping_address.address?.line2}<br/>
+                {o.shipping_address.address?.postal_code} {o.shipping_address.address?.city}
+              </p>
+            </div>
+          )}
+        </section>
+
+        <section className="order-chat">
+          <h2>Concretar la entrega</h2>
+          {data.canMessage?(
+            <>
+              <p className="muted">Conversación privada entre comprador y vendedor. Coordina la forma de pago (en persona o por plataforma) y la entrega.</p>
+              <div className="message-list" aria-live="polite">
+                {!data.messages.length&&(
+                  <div className="empty-state">
+                    <h3>Ya podéis hablar.</h3>
+                    <p>Acordad la forma de pago (en persona o por plataforma) y el lugar o fecha de entrega.</p>
+                  </div>
+                )}
+                {data.messages.map((m:any)=>(
+                  <div key={m.id} className={'message '+(m.sender_id===data.userId?'own':'')}>
+                    <strong>{m.sender_id===data.userId?'Tú':buyer?'Vendedor':'Comprador'}</strong>
+                    <p>{m.content}</p>
+                    <small>{new Date(m.created_at).toLocaleString('es-ES')}</small>
+                  </div>
+                ))}
+              </div>
+              <form onSubmit={e=>{e.preventDefault();action('message')}}>
+                <label htmlFor="message">Mensaje sobre la entrega o pago</label>
+                <textarea className="field-input" id="message" value={content} onChange={e=>setContent(e.target.value)} maxLength={2000} required rows={3}/>
+                <button className="button primary" disabled={busy||!content.trim()}>Enviar mensaje</button>
+              </form>
+            </>
+          ):(
+            <div className="empty-state">
+              <h3>El chat no está disponible.</h3>
+              <p>Solo las partes de un pedido activo pueden acceder a la conversación.</p>
+            </div>
+          )}
+        </section>
+      </div>
+    </>
+  );
+}
+

--- a/src/controllers/marketplace.ts
+++ b/src/controllers/marketplace.ts
@@ -61,6 +61,7 @@ export async function handle(request:Request,path:string[]){try{
   await result(db.from('lp_orders').update({stripe_session_id:session.id,expires_at:new Date((session.expires_at+60)*1000).toISOString()}).eq('id',o.id).eq('status','pending_payment'));return ok({url:session.url});
  }
  if(action==='simulate-payment'&&uuid(id||'')){if(!simulated())return ok({error:'La simulación está desactivada'},403);return ok(await rpc('lp_simulate_payment',{p_order:id,p_actor:user.id}))}
+ if(action==='pay-in-person'&&uuid(id||''))return ok(await rpc('lp_confirm_in_person_payment',{p_order:id,p_actor:user.id}));
  if(action==='message'&&uuid(id||'')){const content=text(body.content,1,2000);const recent=await db.from('lp_messages').select('id',{count:'exact',head:true}).eq('sender_id',user.id).gte('created_at',new Date(Date.now()-60000).toISOString());if((recent.count||0)>=20)return ok({error:'Espera un momento antes de enviar más mensajes.'},429);return ok(await rpc('lp_send_message',{p_order:id,p_actor:user.id,p_content:content}),201)}
  if(['ship','complete'].includes(action)&&uuid(id||''))return ok(await rpc('lp_transition',{p_order:id,p_actor:user.id,p_action:action,p_tracking:body.tracking?text(body.tracking,2,200):null}));
  if(action==='withdraw'&&uuid(id||'')){const rows=await result(db.from('lp_listings').update({status:'withdrawn'}).eq('id',id).eq('seller_id',user.id).eq('status','available').eq('bid_count',0).select('id'));if(!rows.length)throw Error('Solo puedes retirar anuncios disponibles sin pujas.');return ok({success:true})}

--- a/src/lib/__tests__/rules-order-chat.test.ts
+++ b/src/lib/__tests__/rules-order-chat.test.ts
@@ -1,0 +1,31 @@
+import { canMessage } from '../rules';
+
+describe('Order chat authorization rules (LP-FEAT-007)', () => {
+  const buyerId = 'buyer-uuid-1111';
+  const sellerId = 'seller-uuid-2222';
+  const outsiderId = 'outsider-uuid-9999';
+
+  it('allows buyer and seller to message when order is in pending_payment (reserved)', () => {
+    expect(canMessage('pending_payment', buyerId, buyerId, sellerId)).toBe(true);
+    expect(canMessage('pending_payment', sellerId, buyerId, sellerId)).toBe(true);
+  });
+
+  it('allows buyer and seller to message in post-payment active states', () => {
+    const activeStates = ['paid', 'shipped', 'completed', 'disputed'];
+    for (const status of activeStates) {
+      expect(canMessage(status, buyerId, buyerId, sellerId)).toBe(true);
+      expect(canMessage(status, sellerId, buyerId, sellerId)).toBe(true);
+    }
+  });
+
+  it('rejects messaging from outsiders even if order is reserved or paid', () => {
+    expect(canMessage('pending_payment', outsiderId, buyerId, sellerId)).toBe(false);
+    expect(canMessage('paid', outsiderId, buyerId, sellerId)).toBe(false);
+  });
+
+  it('rejects messaging when order is cancelled or refunded', () => {
+    expect(canMessage('cancelled', buyerId, buyerId, sellerId)).toBe(false);
+    expect(canMessage('refunded', buyerId, buyerId, sellerId)).toBe(false);
+    expect(canMessage('unknown', buyerId, buyerId, sellerId)).toBe(false);
+  });
+});

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -7,5 +7,5 @@ export function noContact(value:string){if(/https?:|www\.|\b[\w.+-]+@[\w.-]+\.[a
 export function noBargaining(value:string){if(/(?:^|[^\p{L}\p{N}])(?:regate[ao]|regatear|te doy|te ofrezco|rebaj[ao]|rebajas|rebajar|descuento|[uú]ltimo precio|precio m[ií]nimo|bajar(?:lo|le)? el precio|negociable|contraoferta)(?:$|[^\p{L}\p{N}])/iu.test(value))throw Error('En La Pela el precio no es negociable. Las preguntas deben tratar sobre las características o estado del producto.');return value}
 
 export const uuid=(s:string)=>/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(s);
-export function canMessage(status:string,actor:string,buyer:string,seller:string){return ['paid','shipped','completed','disputed'].includes(status)&&[buyer,seller].includes(actor)}
+export function canMessage(status:string,actor:string,buyer:string,seller:string){return ['pending_payment','paid','shipped','completed','disputed'].includes(status)&&[buyer,seller].includes(actor)}
 

--- a/supabase/migrations/202609090002_chat_on_reservation_and_in_person_pay.sql
+++ b/supabase/migrations/202609090002_chat_on_reservation_and_in_person_pay.sql
@@ -1,0 +1,41 @@
+begin;
+
+-- Permitir 'in_person' en payment_mode de lp_orders
+alter table public.lp_orders drop constraint if exists lp_orders_payment_mode_check;
+alter table public.lp_orders add constraint lp_orders_payment_mode_check check(payment_mode in ('simulation','stripe','in_person'));
+
+-- Actualizar lp_send_message para permitir chat en pending_payment (reserva activa)
+create or replace function public.lp_send_message(p_order uuid,p_actor uuid,p_content text) returns public.lp_messages language plpgsql security definer set search_path=public as $$
+declare o public.lp_orders; m public.lp_messages;
+begin
+ select * into o from lp_orders where id=p_order for update;
+ if not found or p_actor not in(o.buyer_id,o.seller_id) or o.status not in ('pending_payment','paid','shipped','completed','disputed') then
+  raise exception 'El chat se habilita durante la reserva o tras el pago y solo entre las partes del pedido';
+ end if;
+ insert into lp_messages(order_id,sender_id,content) values(p_order,p_actor,trim(p_content)) returning * into m;
+ return m;
+end $$;
+
+-- Crear lp_confirm_in_person_payment para que el vendedor confirme el cobro en persona
+create or replace function public.lp_confirm_in_person_payment(p_order uuid,p_actor uuid) returns public.lp_orders language plpgsql security definer set search_path=public as $$
+declare o public.lp_orders;
+begin
+ select * into o from lp_orders where id=p_order for update;
+ if not found or o.seller_id<>p_actor then
+  raise exception 'Solo el vendedor puede confirmar el pago en persona';
+ end if;
+ if o.status<>'pending_payment' then
+  raise exception 'Solo se puede confirmar el pago en persona de un pedido pendiente de pago';
+ end if;
+ if o.expires_at<=now() then
+  raise exception 'La reserva ya ha expirado';
+ end if;
+ update lp_orders set status='completed',payment_mode='in_person' where id=o.id returning * into o;
+ update lp_listings set status='sold' where id=o.listing_id;
+ return o;
+end $$;
+
+revoke execute on function public.lp_send_message(uuid,uuid,text), public.lp_confirm_in_person_payment(uuid,uuid) from public,anon,authenticated;
+grant execute on function public.lp_send_message(uuid,uuid,text), public.lp_confirm_in_person_payment(uuid,uuid) to service_role;
+
+commit;

--- a/tests/database/marketplace.sql
+++ b/tests/database/marketplace.sql
@@ -1,7 +1,7 @@
 begin;
 -- Everything in this test is rolled back, including the synthetic accounts.
 do $$
-declare seller uuid:=gen_random_uuid(); buyer uuid:=gen_random_uuid(); outsider uuid:=gen_random_uuid(); item uuid; auction uuid; ord public.lp_orders; l public.lp_listings; q public.lp_questions; blocked boolean;
+declare seller uuid:=gen_random_uuid(); buyer uuid:=gen_random_uuid(); outsider uuid:=gen_random_uuid(); item uuid; item2 uuid; auction uuid; ord public.lp_orders; ord2 public.lp_orders; l public.lp_listings; q public.lp_questions; blocked boolean;
 begin
  insert into auth.users(id,email,raw_user_meta_data,raw_app_meta_data,aud,role,created_at,updated_at)
  values(seller,'lp-test-seller-'||seller||'@example.invalid','{}','{}','authenticated','authenticated',now(),now()),(buyer,'lp-test-buyer-'||buyer||'@example.invalid','{}','{}','authenticated','authenticated',now(),now()),(outsider,'lp-test-other-'||outsider||'@example.invalid','{}','{}','authenticated','authenticated',now(),now());
@@ -16,7 +16,8 @@ begin
  ord:=lp_reserve(item,buyer);
  if ord.amount_cents<>2000 or ord.status<>'pending_payment' or ord.expires_at < now() + interval '47 hours' then raise exception 'FAIL reservation';end if;
  blocked:=false;begin perform lp_reserve(item,outsider);exception when others then blocked:=true;end;if not blocked then raise exception 'FAIL double reservation';end if;
- blocked:=false;begin perform lp_send_message(ord.id,buyer,'Mensaje antes de pagar');exception when others then blocked:=true;end;if not blocked then raise exception 'FAIL unpaid chat';end if;
+ perform lp_send_message(ord.id,buyer,'Mensaje durante la reserva');
+ blocked:=false;begin perform lp_send_message(ord.id,outsider,'Intruso reserva');exception when others then blocked:=true;end;if not blocked then raise exception 'FAIL outsider reservation chat';end if;
  update lp_orders set stripe_session_id='test_session_'||ord.id where id=ord.id;
  blocked:=false;begin perform lp_confirm_payment('bad_'||ord.id,ord.id,'test_session_'||ord.id,'test_payment_'||ord.id,1,null);exception when others then blocked:=true;end;if not blocked then raise exception 'FAIL amount mismatch';end if;
  perform lp_confirm_payment('event_'||ord.id,ord.id,'test_session_'||ord.id,'test_payment_'||ord.id,2000,null);
@@ -25,6 +26,14 @@ begin
  blocked:=false;begin perform lp_send_message(ord.id,outsider,'Acceso no permitido');exception when others then blocked:=true;end;if not blocked then raise exception 'FAIL outsider chat';end if;
  blocked:=false;begin perform lp_transition(ord.id,buyer,'ship',null);exception when others then blocked:=true;end;if not blocked then raise exception 'FAIL buyer ships';end if;
  perform lp_transition(ord.id,seller,'ship','Preparado');perform lp_transition(ord.id,buyer,'complete',null);
+ insert into public.lp_listings(seller_id,title,description,category,condition,location,images,mode,price_cents,delivery) values(seller,'Artículo cobro en persona','Descripción válida para comprobar el cobro en persona.','Tecnología','Como nuevo','Madrid',array['https://example.invalid/ip.jpg'],'sale',1500,'pickup') returning id into item2;
+ ord2:=lp_reserve(item2,buyer);
+ blocked:=false;begin perform lp_confirm_in_person_payment(ord2.id,buyer);exception when others then blocked:=true;end;if not blocked then raise exception 'FAIL buyer confirm in person';end if;
+ blocked:=false;begin perform lp_confirm_in_person_payment(ord2.id,outsider);exception when others then blocked:=true;end;if not blocked then raise exception 'FAIL outsider confirm in person';end if;
+ ord2:=lp_confirm_in_person_payment(ord2.id,seller);
+ if ord2.status<>'completed' or ord2.payment_mode<>'in_person' then raise exception 'FAIL in person order status';end if;
+ if (select status from lp_listings where id=item2)<>'sold' then raise exception 'FAIL in person listing sold';end if;
+ blocked:=false;begin perform lp_confirm_in_person_payment(ord2.id,seller);exception when others then blocked:=true;end;if not blocked then raise exception 'FAIL in person already completed';end if;
  insert into public.lp_listings(seller_id,title,description,category,condition,location,images,mode,price_cents,delivery,ends_at) values(seller,'Subasta de prueba','Descripción completa de una subasta sintética para validación.','Hogar','Buen estado','Madrid',array['https://example.invalid/test.jpg'],'auction',1000,'pickup',now()+interval '60 seconds') returning id into auction;
  blocked:=false;begin perform lp_bid(auction,seller,1100);exception when others then blocked:=true;end;if not blocked then raise exception 'FAIL self bid';end if;
  l:=lp_bid(auction,buyer,1000);if l.ends_at<now()+interval '119 seconds' then raise exception 'FAIL anti sniping';end if;
@@ -34,8 +43,8 @@ begin
  perform lp_close_auctions();perform lp_close_auctions();
  if (select count(*) from lp_orders where listing_id=auction)<>1 then raise exception 'FAIL close idempotency';end if;
  if not exists(select 1 from lp_orders where listing_id=auction and buyer_id=outsider and amount_cents=1100) then raise exception 'FAIL winner';end if;
- if has_table_privilege('anon','lp_messages','SELECT') or has_table_privilege('authenticated','lp_orders','UPDATE') or has_function_privilege('authenticated','lp_confirm_payment(text,uuid,text,text,integer,jsonb)','EXECUTE') or has_table_privilege('anon','lp_questions','SELECT') or has_function_privilege('authenticated','lp_ask_question(uuid,uuid,text)','EXECUTE') then raise exception 'FAIL direct privilege';end if;
+ if has_table_privilege('anon','lp_messages','SELECT') or has_table_privilege('authenticated','lp_orders','UPDATE') or has_function_privilege('authenticated','lp_confirm_payment(text,uuid,text,text,integer,jsonb)','EXECUTE') or has_function_privilege('authenticated','lp_confirm_in_person_payment(uuid,uuid)','EXECUTE') or has_table_privilege('anon','lp_questions','SELECT') or has_function_privilege('authenticated','lp_ask_question(uuid,uuid,text)','EXECUTE') then raise exception 'FAIL direct privilege';end if;
 end $$;
 rollback;
-select 'PASS: ownership, questions, reservations, payment amount, payment idempotency, chat authorization, transitions, increments, expiry, anti-sniping, auction close, direct permissions' as result;
+select 'PASS: ownership, questions, reservations, payment amount, payment idempotency, chat authorization, in-person payment, transitions, increments, expiry, anti-sniping, auction close, direct permissions' as result;
 


### PR DESCRIPTION
## Descripción
Habilita el chat del pedido inmediatamente tras la reserva (`pending_payment`) para permitir la coordinación entre comprador y vendedor (pago en mano o por plataforma, y método de entrega). Introduce la función transaccional `lp_confirm_in_person_payment` y acción de interfaz para que el vendedor confirme el cobro en persona, finalizando el pedido como `completed` (`payment_mode = 'in_person'`) y el anuncio como `sold`.

Closes #21

## Especificación y trazabilidad
- Ficha: [LP-FEAT-007](specs/LP-FEAT-007-chat-reserva-cobro-en-persona.md)
- Issue: #21
- Estado de la spec: `VERIFIED`
- Actualización de `PROJECT_CONTEXT.md`: Sí (documentado chat en reserva, cobro en persona, función transaccional y endpoint API).

## Criterios de aceptación comprobados
- [x] AC-01: Pedido en `pending_payment` tiene chat habilitado para comprador y vendedor.
- [x] AC-02: Terceros ajenos al pedido son denegados en chat de reserva.
- [x] AC-03: Vendedor puede marcar cobro en persona con confirmación interactiva, pasando pedido a `completed` y anuncio a `sold`.
- [x] AC-04: Comprador no puede confirmar cobro en persona.

## Evidencia de validación
- `supabase/migrations/202609090002_chat_on_reservation_and_in_person_pay.sql` aplicada con éxito en Supabase remota (HTTP 201).
- Invariantes verificados en `tests/database/marketplace.sql` con resultado `PASS`.
- `src/lib/__tests__/rules-order-chat.test.ts` superado (4/4).
- `src/app/orders/[id]/__tests__/Order.test.tsx` superado (2/2).
- `npm run build` completado sin errores (26 rutas estáticas/SSR).
- `npm run specs:check` y validación de rama validadas.