### PR TITLE
[LP-FEAT-008] Spinner de marca no bloqueante y mejoras en preguntas y respuestas

### DIFF
--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -42,6 +42,7 @@ La propuesta combina la sencillez de uso de un marketplace móvil con dos mecani
 - Ficha de artículo con fotografías, estado, ubicación, entrega, precio y reglas de compra.
 - Rutas semánticas para categorías (`/categoria/:slug`), subastas (`/subastas`) y artículos (`/articulos/:slug-con-id`).
 - Metadatos canónicos y sociales, Schema.org, `robots.txt` y sitemap dinámico para indexación.
+- Indicador no bloqueante con spinner de marca (moneda de La Pela girando en 3D) durante transiciones asíncronas de catálogo y carga diferida de imágenes en tarjetas.
 
 ### Cuenta y autenticación
 
@@ -89,7 +90,7 @@ La propuesta combina la sencillez de uso de un marketplace móvil con dos mecani
 
 - Chat privado exclusivo para comprador y vendedor de un pedido activo: se abre desde el momento de la reserva (`pending_payment`) para acordar el método de pago (en persona o por plataforma) y la entrega, manteniéndose durante los estados pagados y posteriores.
 - Límite de veinte mensajes por minuto y usuario.
-- Preguntas y respuestas públicas en la ficha de producto con paginación de 10 elementos, aviso anti-regateo, bloqueo de datos de contacto y notificaciones de preguntas pendientes para el vendedor.
+- Preguntas y respuestas públicas en la ficha de producto con paginación de 10 elementos, banner normativo con viñetas claras, validación reforzada contra propuestas económicas, ofertas numéricas o trueques, bloqueo de datos de contacto y notificaciones de preguntas pendientes para el vendedor.
 - Seguimiento de compras, ventas, pujas y anuncios en `Mi actividad`.
 - Denuncia de anuncios para revisión.
 

--- a/SPEC_REGISTRY.md
+++ b/SPEC_REGISTRY.md
@@ -60,6 +60,7 @@ Prioridades: `P0` bloquea una operación esencial o implica un riesgo grave; `P1
 | `LP-FEAT-005` | `FEATURE` | Preguntas y respuestas públicas en producto | `VERIFIED` | `P2` | 2026-09-06 | [Abrir ficha](specs/LP-FEAT-005-preguntas-respuestas-producto.md) |
 | `LP-FEAT-006` | `FEATURE` | Confirmación de compra, reserva de 48h y política de compras | `VERIFIED` | `P1` | 2026-09-09 | [Abrir ficha](specs/LP-FEAT-006-confirmacion-reserva-politica-compras.md) |
 | `LP-FEAT-007` | `FEATURE` | Chat en reserva y confirmación de cobro en persona por el vendedor | `VERIFIED` | `P1` | 2026-09-09 | [Abrir ficha](specs/LP-FEAT-007-chat-reserva-cobro-en-persona.md) |
+| `LP-FEAT-008` | `FEATURE` | Spinner de marca no bloqueante y mejoras en preguntas y respuestas | `VERIFIED` | `P2` | 2026-09-09 | [Abrir ficha](specs/LP-FEAT-008-spinner-marca-mejoras-qa.md) |
 
 
 ## Flujo para una solicitud nueva

--- a/specs/LP-FEAT-008-spinner-marca-mejoras-qa.md
+++ b/specs/LP-FEAT-008-spinner-marca-mejoras-qa.md
@@ -1,0 +1,137 @@
+---
+id: LP-FEAT-008
+type: FEATURE
+status: VERIFIED
+priority: P2
+requested_at: 2026-09-09
+requested_by: usuario
+source: conversación
+owner: producto
+github_issue: https://github.com/jorgeluquerubia/lapela/issues/23
+related_specs: [LP-FEAT-001, LP-FEAT-005]
+dependencies: []
+cross_cutting_concerns: [accesibilidad, diseño]
+---
+
+# LP-FEAT-008 · Spinner de marca no bloqueante y mejoras en preguntas y respuestas
+
+## 1. Solicitud original
+
+> - Spinner no bloqueante con la moneda/logo de La Pela girando durante la carga asíncrona (por ejemplo clics en categorías, carga de imágenes) en lugar de placeholders vacíos.
+> - Revisar y corregir el formato del banner de reglas en la sección de preguntas y respuestas (`ProductQA`).
+> - Reforzar la validación estricta en preguntas y respuestas contra regateos y términos prohibidos.
+
+## 2. Contexto y problema
+
+- **Problema u oportunidad:**
+  1. Durante la navegación asíncrona (filtros, categorías) y la carga de imágenes, la interfaz presentaba cajas grises vacías o parpadeos bruscos (`loading-card`) sin identidad de marca ni comunicación fluida.
+  2. En la sección de preguntas y respuestas (`ProductQA`), el banner explicativo de la normativa presentaba problemas de formateo visual derivados del reseteo de estilos de listas en CSS/Tailwind (las viñetas `ul/li` no se mostraban adecuadamente, afectando la legibilidad).
+  3. Los usuarios podían eludir el filtro anti-regateo utilizando variantes comunes de negociación en español ("me lo dejas en X", "te ofrezco X", "te pago X en mano", "haces rebaja", trueques, etc.).
+- **Personas afectadas:** Compradores y vendedores navegando por el catálogo, visualizando fotos de productos o interactuando en las preguntas públicas de la ficha.
+- **Impacto actual:** Experiencia de carga despersonalizada, reglas de Q&A con presentación descuidada y riesgo de regateos en un portal con política estricta de precio no negociable.
+- **Evidencia disponible:** Solicitud del usuario, reseteos en `globals.css` y casos de prueba en `rules-qa.test.ts`.
+
+## 3. Resultado esperado
+
+- Un componente reutilizable `BrandSpinner` que muestra la moneda/logo oficial de La Pela (`lp ↗`) girando de forma continua, accesible (`role="status"`, `aria-label`), adaptable a tamaños (`sm`, `md`, `lg`) y respetando `prefers-reduced-motion`.
+- Integración no bloqueante en el catálogo y en las tarjetas de producto durante la carga de imágenes.
+- Banner de reglas de Q&A formateado de manera atractiva, con viñetas visibles, margen e iconografía limpia.
+- Regla `noBargaining` reforzada con un léxico exhaustivo de regateo, detección de ofertas económicas monetarias y bloqueo estricto.
+
+## 4. Alcance
+
+### Incluido
+
+- Componente accesible `src/components/BrandSpinner.tsx`.
+- Estilos de animación 3D / giro de moneda en `src/app/globals.css`.
+- Integración de `BrandSpinner` en `src/components/Catalog.tsx` (toolbar y estados de recarga de catálogo).
+- Integración de `BrandSpinner` en `src/components/ProductCard.tsx` durante la carga de imágenes.
+- Corrección de formato del banner de normas en `src/components/ProductQA.tsx` y `src/app/globals.css`.
+- Ampliación del validador `noBargaining` en `src/lib/rules.ts` con diccionario ampliado y detección de números/cantidades con intención de oferta.
+- Pruebas unitarias de las nuevas reglas y pruebas del componente spinner.
+
+### Excluido
+
+- Cambios en el esquema de base de datos (no requeridos para esta mejora de UI y validación de dominio).
+
+## 5. Requisitos y reglas de negocio
+
+### Requisitos funcionales
+
+- `RF-01`: La aplicación cuenta con un spinner de marca (`BrandSpinner`) que representa la moneda/icono de La Pela girando.
+- `RF-02`: Al navegar entre categorías o filtros en el catálogo, se muestra el indicador no bloqueante con el spinner de marca sin destruir el diseño circundante.
+- `RF-03`: En las tarjetas de producto, mientras la imagen se descarga de red, se muestra el spinner centrado en lugar de un hueco estático sin feedback.
+- `RF-04`: El banner de normas de preguntas y respuestas en `ProductQA` presenta viñetas con viñeta visible (`list-disc`), sangría adecuada y jerarquía tipográfica limpia.
+- `RF-05`: La función `noBargaining` rechaza ofertas numéricas ("te doy 30€", "te ofrezco 20"), expresiones de rebaja ("me lo dejas en", "precio final", "rebajita") e intentos de trueque/intercambio.
+
+### Requisitos no funcionales
+
+- `RNF-01`: `BrandSpinner` debe incluir soporte para usuarios con sensibilidad al movimiento mediante `prefers-reduced-motion: reduce`.
+- `RNF-02`: Los elementos de carga deben disponer de atributos semánticos ARIA (`role="status"`, texto accesible).
+
+### Reglas de negocio
+
+- `RN-01`: En La Pela el precio es fijo (o por pujas en subastas); ninguna pregunta pública puede formular contraofertas o propuestas de rebaja.
+
+## 6. Criterios de aceptación
+
+- [x] `AC-01` Dado un usuario visualizando una tarjeta de producto en el catálogo cuya imagen está en proceso de carga, entonces visualiza el spinner con la moneda de La Pela girando en el contenedor hasta completarse la carga.
+- [x] `AC-02` Dado un usuario cambiando de categoría o filtros en el catálogo, entonces se muestra el indicador con `BrandSpinner` informando del estado de búsqueda de forma no bloqueante.
+- [x] `AC-03` Dado un usuario en la ficha de producto en la sección de preguntas y respuestas, entonces visualiza el banner de normativa con estilo visual destacado y lista con viñetas claramente legibles.
+- [x] `AC-04` Dado un comprador intentando enviar preguntas con expresiones de regateo ("te ofrezco 40", "me lo dejas por 15", "haces trueque"), entonces el sistema bloquea el envío con un mensaje que informa de que el precio no es negociable.
+
+## 7. Experiencia y estados
+
+- Spinner de moneda: moneda circular blanca/verde con `lp ↗`, rotación en eje Y suave, sombras discretas y borde verde característico de La Pela.
+- Banner de reglas: borde lateral verde, viñetas sangradas con `list-disc` y texto diferenciado.
+
+## 8. Datos, API, seguridad y operación
+
+- No requiere nuevas tablas ni migraciones SQL.
+- `src/lib/rules.ts` (`noBargaining`) se ejecuta tanto en cliente (en el componente antes de enviar) como en el backend (`src/controllers/marketplace.ts`).
+
+## 9. Plan de validación
+
+| Comprobación | Resultado esperado | Evidencia | Fecha |
+|---|---|---|---|
+| Pruebas unitarias de regateo | Rechazo de todas las variantes de regateo, ofertas y trueque | `src/lib/__tests__/rules-qa.test.ts` (4/4 pruebas superadas) | 2026-09-09 |
+| Pruebas de componente BrandSpinner | Renderiza con atributos ARIA y clases de tamaño | `src/components/__tests__/BrandSpinner.test.tsx` (2/2 pruebas superadas) | 2026-09-09 |
+| Pruebas de tarjeta con carga de imagen | Spinner presente hasta disparo de evento `load` | `src/components/__tests__/ProductCard.test.tsx` (2/2 pruebas superadas) | 2026-09-09 |
+| Pruebas de componente ProductQA | Banner de reglas y estilos de lista presentes | `src/components/__tests__/ProductQA.test.tsx` (5/5 pruebas superadas) | 2026-09-09 |
+| `npm run specs:check` | Ficha registrada y gobernanza documental correcta | 16 fichas registradas y 27 documentos enlazados | 2026-09-09 |
+| `npm run build` | Compilación Next.js limpia sin errores | 26 páginas estáticas/SSR generadas sin errores | 2026-09-09 |
+
+## 10. Decisiones, riesgos y preguntas abiertas
+
+- **Decisiones:**
+  - Mantener los productos visibles con opacidad reducida durante recargas de filtros para evitar saltos bruscos de maquetación (Cumulative Layout Shift).
+  - Emplear rotación 3D en eje Y para simular una moneda en giro continuo.
+- **Riesgos y límites:**
+  - Falsos positivos en `noBargaining`: las expresiones se limitan a contextos de oferta económica y no bloquean preguntas legítimas sobre el estado ("¿tiene algún detalle?").
+
+## 11. Implementación y trazabilidad
+
+- **Archivos o módulos:**
+  - `specs/LP-FEAT-008-spinner-marca-mejoras-qa.md`
+  - `SPEC_REGISTRY.md`
+  - `PROJECT_CONTEXT.md`
+  - `src/components/BrandSpinner.tsx`
+  - `src/components/ProductCard.tsx`
+  - `src/components/Catalog.tsx`
+  - `src/components/ProductQA.tsx`
+  - `src/lib/rules.ts`
+  - `src/app/globals.css`
+  - `src/lib/__tests__/rules-qa.test.ts`
+  - `src/components/__tests__/BrandSpinner.test.tsx`
+  - `src/components/__tests__/ProductCard.test.tsx`
+  - `src/components/__tests__/ProductQA.test.tsx`
+- **Migraciones/configuración:** N/A
+- **Commit o despliegue:** Rama `gemini/lp-feat-008-spinner-marca-mejoras-qa`
+- **Notas de implementación:** Rama `gemini/lp-feat-008-spinner-marca-mejoras-qa`.
+
+## 12. Historial
+
+| Fecha | Estado | Cambio | Autor/agente |
+|---|---|---|---|
+| 2026-09-09 | `IN_PROGRESS` | Creación de especificación e inicio de implementación | Gemini |
+| 2026-09-09 | `VERIFIED` | Implementación de BrandSpinner, mejoras en ProductQA y validación completa | Gemini |

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,11 +9,39 @@
 .forgot-link{align-self:flex-end;margin-top:-5px}
 
 .qa-section{margin-top:40px;border-top:1px solid var(--line);padding-top:30px}
-.qa-rule-banner{background:#f4f7f4;border:1px solid #d2ded5;border-radius:12px;padding:16px 20px;font-size:14px;margin-bottom:24px;color:var(--ink)}
-.qa-rule-banner strong{display:block;color:var(--green-dark);margin-bottom:6px;font-size:15px}
-.qa-rule-banner ul{margin:6px 0 0 18px;padding:0;color:#374942}
-.qa-rule-banner li{margin-bottom:3px}
+.qa-rule-banner{background:#f4f7f4;border:1px solid #d2ded5;border-left:4px solid var(--green);border-radius:12px;padding:16px 20px;font-size:14px;margin-bottom:24px;color:var(--ink)}
+.qa-rule-banner strong{display:block;color:var(--green-dark);margin-bottom:8px;font-size:15px;font-weight:700}
+.qa-rule-banner ul{list-style:disc !important;list-style-type:disc !important;margin:8px 0 0 20px !important;padding-left:4px !important;color:#374942}
+.qa-rule-banner li{margin-bottom:6px;line-height:1.5;list-style:disc !important}
 .qa-form{margin-bottom:32px;background:var(--surface);padding:22px;border-radius:14px;border:1px solid var(--line)}
+
+/* BrandSpinner */
+.brand-spinner{display:inline-flex;align-items:center;justify-content:center}
+.brand-spinner-coin{position:relative;display:inline-flex;align-items:center;justify-content:center;border-radius:50%;border:2px solid var(--green);color:var(--green);background:#fff;box-shadow:0 2px 6px rgba(18,100,71,.12);animation:brand-coin-spin 1.2s cubic-bezier(.45,.05,.55,.95) infinite;user-select:none;line-height:1}
+.brand-spinner-sm{width:22px;height:22px;font-size:12px;border-width:1.5px;letter-spacing:-1.5px;padding-right:2px}
+.brand-spinner-sm .brand-spinner-arrow{position:absolute;right:-4px;top:-6px;font-size:11px;background:#fff;line-height:1;padding:1px}
+.brand-spinner-md{width:36px;height:36px;font-size:19px;border-width:2px;letter-spacing:-2.5px;padding-right:4px}
+.brand-spinner-md .brand-spinner-arrow{position:absolute;right:-5px;top:-8px;font-size:17px;background:#fff;line-height:1;padding:1px}
+.brand-spinner-lg{width:54px;height:54px;font-size:27px;border-width:2.5px;letter-spacing:-3px;padding-right:6px}
+.brand-spinner-lg .brand-spinner-arrow{position:absolute;right:-7px;top:-11px;font-size:23px;background:#fff;line-height:1;padding:2px}
+.brand-spinner-lp{font-weight:800}
+
+@keyframes brand-coin-spin{
+  0%{transform:perspective(400px) rotateY(0deg)}
+  50%{transform:perspective(400px) rotateY(180deg)}
+  100%{transform:perspective(400px) rotateY(360deg)}
+}
+
+@media (prefers-reduced-motion: reduce){
+  .brand-spinner-coin{animation-duration:4s}
+}
+
+.product-image-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;background:var(--surface);z-index:1;transition:opacity .2s ease-out}
+.product-image-loaded{opacity:1;transition:opacity .25s ease-in}
+.product-image-unloaded{opacity:0}
+
+.catalog-updating-banner{display:inline-flex;align-items:center;gap:8px;font-size:13px;color:var(--green);font-weight:600;background:#edf4ed;padding:4px 10px;border-radius:20px}
+.catalog-grid-updating{opacity:.6;pointer-events:auto;transition:opacity .15s ease}
 .qa-form textarea{min-height:95px;resize:vertical}
 .qa-card{border:1px solid var(--line);border-radius:12px;padding:18px 20px;margin-bottom:16px;background:white}
 .qa-question{display:flex;flex-direction:column;gap:6px}

--- a/src/components/BrandSpinner.tsx
+++ b/src/components/BrandSpinner.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+interface BrandSpinnerProps {
+  size?: 'sm' | 'md' | 'lg';
+  label?: string;
+  className?: string;
+}
+
+export default function BrandSpinner({
+  size = 'md',
+  label = 'Cargando…',
+  className = '',
+}: BrandSpinnerProps) {
+  return (
+    <div
+      role="status"
+      aria-label={label}
+      className={`brand-spinner ${className}`}
+    >
+      <div className={`brand-spinner-coin brand-spinner-${size}`} aria-hidden="true">
+        <span className="brand-spinner-lp">lp</span>
+        <span className="brand-spinner-arrow">↗</span>
+      </div>
+      <span className="sr-only">{label}</span>
+    </div>
+  );
+}

--- a/src/components/Catalog.tsx
+++ b/src/components/Catalog.tsx
@@ -4,6 +4,7 @@ import {useSearchParams} from 'next/navigation';
 import Link from 'next/link';
 import {Product} from '@/types';
 import ProductCard from './ProductCard';
+import BrandSpinner from './BrandSpinner';
 import {demoProducts} from '@/lib/demo-products';
 import {categoryToSlug, slugify} from '@/lib/slugs';
 
@@ -140,7 +141,16 @@ export default function Catalog({initialCategory, initialMode}: CatalogProps = {
 
       <section aria-label="Productos">
         <div className="catalog-toolbar">
-          <span className="muted">{loading?'Buscando artículos…':`${count} artículos${category!=='Todas'?' en '+category:''}`}</span>
+          <div className="flex items-center gap-3">
+            {loading ? (
+              <div className="catalog-updating-banner" role="status">
+                <BrandSpinner size="sm" label="Actualizando catálogo" />
+                <span>Buscando artículos…</span>
+              </div>
+            ) : (
+              <span className="muted">{`${count} artículos${category!=='Todas'?' en '+category:''}`}</span>
+            )}
+          </div>
           <button className="button mobile-filters" aria-expanded={filters} onClick={()=>setFilters(!filters)}>Filtros</button>
           <select aria-label="Ordenar productos" value={sort} onChange={e=>{setSort(e.target.value);setPage(1)}}>
             <option value="recent">Más recientes</option>
@@ -159,9 +169,16 @@ export default function Catalog({initialCategory, initialMode}: CatalogProps = {
           </div>
         ) : (
           <>
-            <div className="product-grid">
-              {loading?Array.from({length:6},(_,i)=><div className="loading-card" key={i}/>):products.map(p=><ProductCard key={p.id} product={p}/>)}
-            </div>
+            {loading && !products.length ? (
+              <div className="empty-state py-16" role="status">
+                <BrandSpinner size="lg" label="Cargando artículos de La Pela…" />
+                <p className="mt-4 font-medium text-stone-600">Buscando los mejores artículos de segunda mano…</p>
+              </div>
+            ) : (
+              <div className={`product-grid ${loading ? 'catalog-grid-updating' : ''}`}>
+                {products.map(p=><ProductCard key={p.id} product={p}/>)}
+              </div>
+            )}
 
             {!loading&&!products.length&&(
               <div className="empty-state">

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -1,14 +1,29 @@
+'use client';
+import {useState} from 'react';
 import Link from 'next/link';
 import {Product} from '@/types';
 import {productSlug} from '@/lib/slugs';
+import BrandSpinner from './BrandSpinner';
 
 export default function ProductCard({product:p}:{product:Product}){
+  const [imageLoaded, setImageLoaded] = useState(false);
   const auction=p.type==='auction';
   const time=p.auction_ends_at?Math.max(0,Math.ceil((Date.parse(p.auction_ends_at)-Date.now())/3600000)):null;
   const href=`/articulos/${p.slug||productSlug(p.id,p.name)}`;
   return <article className="product-card">
     <Link href={href} className="product-image">
-      <img src={p.image} alt={p.name} loading="lazy"/>
+      {!imageLoaded && (
+        <div className="product-image-loading">
+          <BrandSpinner size="sm" label={`Cargando imagen de ${p.name}…`} />
+        </div>
+      )}
+      <img
+        src={p.image}
+        alt={p.name}
+        loading="lazy"
+        onLoad={() => setImageLoaded(true)}
+        className={imageLoaded ? 'product-image-loaded' : 'product-image-unloaded'}
+      />
       <span className={`sale-tag ${auction?'auction':''}`}>{auction?'↗ Subasta':'Precio cerrado'}</span>
     </Link>
     <div className="product-info">

--- a/src/components/ProductQA.tsx
+++ b/src/components/ProductQA.tsx
@@ -2,6 +2,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
 import { api } from '@/lib/api';
+import BrandSpinner from './BrandSpinner';
 
 export interface QuestionItem {
   id: string;
@@ -131,7 +132,7 @@ export default function ProductQA({ listingId, isSeller, user, demo = false }: P
 
       <div className="qa-rule-banner">
         <strong>Normativa de la sección de preguntas:</strong>
-        <ul>
+        <ul className="list-disc pl-5 space-y-1.5 mt-2">
           <li>
             Las preguntas deben ceñirse a la <strong>naturaleza, detalles, especificaciones o estado</strong> del producto.
           </li>
@@ -206,7 +207,10 @@ export default function ProductQA({ listingId, isSeller, user, demo = false }: P
       {/* Listado de preguntas */}
       <div className="qa-list">
         {loading ? (
-          <p className="muted py-4">Cargando preguntas…</p>
+          <div className="flex items-center gap-3 py-6 text-stone-600 font-medium" role="status">
+            <BrandSpinner size="sm" label="Cargando preguntas…" />
+            <span>Cargando preguntas…</span>
+          </div>
         ) : questions.length === 0 ? (
           <div className="empty-state">
             <p className="m-0 font-medium">Aún no hay preguntas sobre este artículo.</p>

--- a/src/components/__tests__/BrandSpinner.test.tsx
+++ b/src/components/__tests__/BrandSpinner.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import BrandSpinner from '../BrandSpinner';
+
+describe('BrandSpinner component (LP-FEAT-008)', () => {
+  it('renders with role="status" and default accessible label', () => {
+    render(<BrandSpinner />);
+    const spinner = screen.getByRole('status');
+    expect(spinner).toBeInTheDocument();
+    expect(spinner).toHaveAttribute('aria-label', 'Cargando…');
+    expect(screen.getByText('Cargando…')).toHaveClass('sr-only');
+    expect(screen.getByText('lp')).toBeInTheDocument();
+    expect(screen.getByText('↗')).toBeInTheDocument();
+  });
+
+  it('applies custom label and size class', () => {
+    const { container, rerender } = render(<BrandSpinner size="sm" label="Buscando productos…" />);
+    expect(screen.getByRole('status')).toHaveAttribute('aria-label', 'Buscando productos…');
+    expect(container.querySelector('.brand-spinner-sm')).toBeInTheDocument();
+
+    rerender(<BrandSpinner size="lg" label="Cargando catálogo…" className="custom-class" />);
+    expect(container.querySelector('.brand-spinner-lg')).toBeInTheDocument();
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/ProductCard.test.tsx
+++ b/src/components/__tests__/ProductCard.test.tsx
@@ -45,4 +45,20 @@ describe('ProductCard', () => {
     expect(image).toBeInTheDocument();
     expect(image).toHaveAttribute('src', 'https://example.com/image.jpg');
   });
+
+  it('shows BrandSpinner while image is loading and displays image on load', () => {
+    const { fireEvent } = require('@testing-library/react');
+    render(<ProductCard product={mockProduct} />);
+
+    // BrandSpinner is displayed initially
+    expect(screen.getByRole('status', { name: /Cargando imagen de Producto de Prueba…/i })).toBeInTheDocument();
+
+    // Trigger image load
+    const image = screen.getByAltText('Producto de Prueba');
+    fireEvent.load(image);
+
+    // Spinner is removed and image receives loaded class
+    expect(screen.queryByRole('status', { name: /Cargando imagen de Producto de Prueba…/i })).not.toBeInTheDocument();
+    expect(image).toHaveClass('product-image-loaded');
+  });
 });

--- a/src/lib/__tests__/rules-qa.test.ts
+++ b/src/lib/__tests__/rules-qa.test.ts
@@ -6,9 +6,12 @@ describe('Domain rules for Q&A (LP-FEAT-005)', () => {
       expect(noBargaining('¿Viene con caja original y cables?')).toBe('¿Viene con caja original y cables?');
       expect(noBargaining('¿Tiene algún golpe en las esquinas o marcas de uso?')).toBe('¿Tiene algún golpe en las esquinas o marcas de uso?');
       expect(noBargaining('¿De qué año es el modelo?')).toBe('¿De qué año es el modelo?');
+      // Legitimate questions with words like "cambio" or "marchas"
+      expect(noBargaining('¿Funciona suave el cambio Shimano de la bicicleta?')).toBe('¿Funciona suave el cambio Shimano de la bicicleta?');
+      expect(noBargaining('¿Se le ha hecho recientemente algún cambio de batería o pantalla?')).toBe('¿Se le ha hecho recientemente algún cambio de batería o pantalla?');
     });
 
-    it('rejects bargaining attempts', () => {
+    it('rejects bargaining attempts and varied negotiation forms', () => {
       expect(() => noBargaining('¿Aceptas regateo?')).toThrow(/no es negociable/);
       expect(() => noBargaining('Te doy 50 euros y me lo llevo')).toThrow(/no es negociable/);
       expect(() => noBargaining('¿Me haces una rebaja?')).toThrow(/no es negociable/);
@@ -16,6 +19,14 @@ describe('Domain rules for Q&A (LP-FEAT-005)', () => {
       expect(() => noBargaining('¿Haces algún descuento si recojo hoy?')).toThrow(/no es negociable/);
       expect(() => noBargaining('¿El precio es negociable?')).toThrow(/no es negociable/);
       expect(() => noBargaining('¿Podrías bajar el precio?')).toThrow(/no es negociable/);
+      expect(() => noBargaining('¿Me lo dejas en 30 euros?')).toThrow(/no es negociable/);
+      expect(() => noBargaining('Déjamelo por 40 y te lo compro ya')).toThrow(/no es negociable/);
+      expect(() => noBargaining('Te ofrezco 60€')).toThrow(/no es negociable/);
+      expect(() => noBargaining('Te pago 25€ en mano')).toThrow(/no es negociable/);
+      expect(() => noBargaining('¿Aceptas cambios por una consola?')).toThrow(/no es negociable/);
+      expect(() => noBargaining('¿Haces trueques?')).toThrow(/no es negociable/);
+      expect(() => noBargaining('Te lo cambio por un móvil')).toThrow(/no es negociable/);
+      expect(() => noBargaining('50€ en mano')).toThrow(/no es negociable/);
     });
   });
 

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -4,7 +4,17 @@ export const money=(cents:number)=>new Intl.NumberFormat('es-ES',{style:'currenc
 export function cents(value:unknown){const n=Number(value);if(!Number.isFinite(n)||n<1||n>10000||Math.abs(n*100-Math.round(n*100))>0.00001)throw Error('Indica un importe entre 1 y 10.000 €, con un máximo de dos decimales.');return Math.round(n*100)}
 export function text(value:unknown,min:number,max:number){if(typeof value!=='string'||value.trim().length<min||value.trim().length>max)throw Error(`El texto debe tener entre ${min} y ${max} caracteres.`);return value.trim()}
 export function noContact(value:string){if(/https?:|www\.|\b[\w.+-]+@[\w.-]+\.[a-z]{2,}|(?:\+34[\s.-]*)?(?:\d[\s.-]*){9,}|whats?app|telegram|instagram|@[a-z0-9_]{3,}/i.test(value))throw Error('No incluyas teléfonos, enlaces ni datos de contacto.');return value}
-export function noBargaining(value:string){if(/(?:^|[^\p{L}\p{N}])(?:regate[ao]|regatear|te doy|te ofrezco|rebaj[ao]|rebajas|rebajar|descuento|[uú]ltimo precio|precio m[ií]nimo|bajar(?:lo|le)? el precio|negociable|contraoferta)(?:$|[^\p{L}\p{N}])/iu.test(value))throw Error('En La Pela el precio no es negociable. Las preguntas deben tratar sobre las características o estado del producto.');return value}
+export function noBargaining(value:string){
+  const bargainingKeywords = /(?:^|[^\p{L}\p{N}])(?:regate[a-z]*|rebaj[a-z]*|descuent[a-z]*|contraofert[a-z]*|negoci[a-z]*|[uú]ltimo precio|precio m[ií]nimo|precio final|bajar(?:lo|le|se)?(?: el)? precio|bajad[a-z]*|ajustar(?: el)? precio|por cu[aá]nto (?:me )?lo dejas|algo menos|por menos)(?:$|[^\p{L}\p{N}])/iu;
+  const offerPatterns = /(?:^|[^\p{L}\p{N}])(?:te doy|te ofrezco|te dar[ií]a|te ofrecer[ií]a|te pago|te pagar[ií]a|te lo compro(?: por)?|lo compro por|me lo dejas(?: en| por)?|d[eé]jamelo(?: en| por)?|lo dejas(?: en| por)?|aceptas?(?: una)? oferta|mi oferta es)(?:$|[^\p{L}\p{N}])/iu;
+  const barterPatterns = /(?:^|[^\p{L}\p{N}])(?:trueque[s]?|cambi[ao]s? por|te lo cambio por|intercambi[ao]s? por|aceptas? (?:cambios?|trueques?)|haces? (?:cambios?|trueques?))(?:$|[^\p{L}\p{N}])/iu;
+  const cashOfferPatterns = /\b\d+\s*(?:€|euros?)\s*(?:y me lo llevo|y trato hecho|en mano|hoy mismo|ya|te parece|te valen|te sirven)\b/iu;
+
+  if(bargainingKeywords.test(value) || offerPatterns.test(value) || barterPatterns.test(value) || cashOfferPatterns.test(value)){
+    throw Error('En La Pela el precio no es negociable. Las preguntas deben tratar sobre las características o estado del producto.');
+  }
+  return value;
+}
 
 export const uuid=(s:string)=>/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(s);
 export function canMessage(status:string,actor:string,buyer:string,seller:string){return ['pending_payment','paid','shipped','completed','disputed'].includes(status)&&[buyer,seller].includes(actor)}


### PR DESCRIPTION
## Descripción
Implementa el componente accesible `BrandSpinner` (moneda de La Pela 'lp ↗' con animación de giro 3D en eje Y y soporte para `prefers-reduced-motion`) e integración no bloqueante en catálogo y carga diferida de imágenes. Corrige el formato del banner de normativa en la sección de preguntas y respuestas (`ProductQA`) con viñetas visibles (`list-disc`) y refuerza la validación estricta anti-regateo (`noBargaining`) para bloquear contraofertas, propuestas económicas y trueques.

Closes #23

## Especificación y trazabilidad
- Ficha: [LP-FEAT-008](specs/LP-FEAT-008-spinner-marca-mejoras-qa.md)
- Issue: #23
- Estado de la spec: `VERIFIED`
- Actualización de `PROJECT_CONTEXT.md`: Sí (documentado indicador con spinner de marca en catálogo e imágenes, y validación reforzada con banner de viñetas en Q&A).

## Criterios de aceptación comprobados
- [x] AC-01: `ProductCard` muestra el spinner con la moneda de La Pela girando durante la descarga de imagen sin saltos bruscos.
- [x] AC-02: `Catalog` muestra el indicador con `BrandSpinner` durante la navegación entre categorías/filtros de forma no bloqueante.
- [x] AC-03: `ProductQA` muestra el banner normativo con sangría y viñetas visibles (`list-disc`).
- [x] AC-04: `noBargaining` bloquea intentos de regateo, ofertas de precio y trueques sin falsos positivos para términos legítimos de componentes o estado.

## Evidencia de validación
- `src/lib/__tests__/rules-qa.test.ts` superado (4/4).
- `src/components/__tests__/BrandSpinner.test.tsx` superado (2/2).
- `src/components/__tests__/ProductCard.test.tsx` superado (2/2).
- `src/components/__tests__/ProductQA.test.tsx` superado (5/5).
- `npm run build` completado con 26 páginas estáticas/SSR sin errores.
- `npm run specs:check` y validación de rama validadas.