### PR TITLE
[LP-FEAT-011] Aviso de nuevas pujas al vendedor

### DIFF
--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -80,6 +80,7 @@ La propuesta combina la sencillez de uso de un marketplace móvil con dos mecani
 
 - Primera puja igual o superior al precio de salida.
 - Incremento mínimo de 1 € a partir de la primera puja.
+- Cada puja válida avisa al vendedor de la subasta.
 - Prohibición de pujar por un artículo propio.
 - Extensión anti-sniping: una puja en los dos últimos minutos amplía el cierre hasta dos minutos después de esa puja.
 - Cierre idempotente: sin pujas, el anuncio expira y avisa al vendedor; con pujas, crea un pedido y avisa al ganador y al vendedor.
@@ -200,14 +201,14 @@ Las claves secretas no deben usar el prefijo `NEXT_PUBLIC_`, aparecer en specs, 
 - `lp_orders`: comprador, vendedor, importe, pago, dirección, seguimiento y estado.
 - `lp_messages`: conversación ligada al pedido.
 - `lp_questions`: preguntas y respuestas públicas del producto y estado de notificación.
-- `lp_notifications`: registro y persistencia de lectura de novedades por usuario y artículo/pedido (ventas, chat, sobrepujas, cierre de subasta, pagos, expiraciones y cambios de estado).
+- `lp_notifications`: registro y persistencia de lectura de novedades por usuario y artículo/pedido (ventas, chat, pujas recibidas y superadas, cierre de subasta, pagos, expiraciones y cambios de estado).
 - `lp_accounts`: cuenta Stripe Connect del vendedor.
 - `lp_reports`: denuncias de anuncios o pedidos.
 - `lp_payment_events`: idempotencia de eventos Stripe.
 
 ### Funciones transaccionales
 
-- `lp_bid`: valida y registra una puja bajo bloqueo de fila, y notifica por sobrepuja (`outbid`) al pujador previo superado.
+- `lp_bid`: valida y registra una puja bajo bloqueo de fila, notifica la nueva puja al vendedor (`bid_received`) y la sobrepuja (`outbid`) al pujador previo superado.
 - `lp_reserve`: crea una reserva única por 48h, evita la autocompra y la doble venta, y notifica al vendedor de la nueva venta.
 - `lp_close_auctions`: cierra subastas, adjudica al mejor postor y notifica el resultado a las partes afectadas.
 - `lp_confirm_payment`: valida evento, sesión, importe e idempotencia de Stripe, y avisa al vendedor del pago confirmado.

--- a/SPEC_REGISTRY.md
+++ b/SPEC_REGISTRY.md
@@ -64,6 +64,7 @@ Prioridades: `P0` bloquea una operación esencial o implica un riesgo grave; `P1
 | `LP-FEAT-009` | `FEATURE` | Badges de novedades en artículos y ajustes informativos de reserva | `VERIFIED` | `P1` | 2026-09-09 | [Abrir ficha](specs/LP-FEAT-009-notificaciones-articulos.md) |
 | `LP-FEAT-010` | `FEATURE` | Notificaciones contextuales y cierre de subastas | `VERIFIED` | `P1` | 2026-09-10 | [Abrir ficha](specs/LP-FEAT-010-notificaciones-contextuales.md) |
 | `LP-FIX-003` | `FIX` | Entrega fiable de novedades en la campana | `VERIFIED` | `P1` | 2026-09-10 | [Abrir ficha](specs/LP-FIX-003-panel-notificaciones.md) |
+| `LP-FEAT-011` | `FEATURE` | Aviso de nuevas pujas al vendedor | `VERIFIED` | `P1` | 2026-09-10 | [Abrir ficha](specs/LP-FEAT-011-aviso-pujas-vendedor.md) |
 
 
 ## Flujo para una solicitud nueva

--- a/specs/LP-FEAT-011-aviso-pujas-vendedor.md
+++ b/specs/LP-FEAT-011-aviso-pujas-vendedor.md
@@ -1,0 +1,107 @@
+---
+id: LP-FEAT-011
+type: FEATURE
+status: VERIFIED
+priority: P1
+requested_at: 2026-09-10
+requested_by: usuario
+source: conversación
+owner: producto
+github_issue: https://github.com/jorgeluquerubia/lapela/issues/31
+related_specs: [LP-FEAT-009, LP-FEAT-010]
+dependencies: []
+cross_cutting_concerns: [notificaciones, subastas]
+---
+
+# LP-FEAT-011 · Aviso de nuevas pujas al vendedor
+
+## 1. Solicitud original
+
+> "Además he publicado un artículo, alguien ha pujado y tampoco me ha llegado ninguna notificación."
+
+## 2. Contexto y problema
+
+- **Problema u oportunidad:** Las reglas anteriores alertaban solo al pujador superado. Una puja válida no generaba ningún aviso al propietario de la subasta.
+- **Personas afectadas:** Vendedores de artículos en modalidad subasta.
+- **Impacto actual:** El vendedor puede desconocer que su subasta ha recibido actividad hasta entrar manualmente a revisarla.
+
+## 3. Resultado esperado
+
+Cada puja válida de otra persona crea para el vendedor una novedad persistente «Nueva puja», visible en la campana y en Mi actividad, con enlace a la subasta.
+
+## 4. Alcance
+
+### Incluido
+
+- Tipo `bid_received` de notificación.
+- Registro transaccional al aceptar una puja válida.
+- Badge y enlace a la subasta desde las superficies de notificaciones existentes.
+- Pruebas SQL e interfaz de regresión.
+
+### Excluido
+
+- Alertas por correo o push.
+- Agrupación o preferencias de frecuencia de pujas.
+
+## 5. Requisitos y reglas de negocio
+
+### Requisitos funcionales
+
+- `RF-01`: Una puja válida debe crear una notificación no leída para el vendedor de la subasta.
+- `RF-02`: La novedad debe mostrar «Nueva puja» y permitir abrir el artículo subastado.
+
+### Requisitos no funcionales
+
+- `RNF-01`: La notificación se crea en la misma transacción que la puja, sin exponer un estado de puja aceptada sin aviso.
+
+### Reglas de negocio
+
+- `RN-01`: Solo una puja que supera el mínimo y queda registrada crea el aviso; intentos inválidos no lo hacen.
+- `RN-02`: El vendedor no puede pujar en su propio artículo y nunca recibe una notificación causada por sí mismo.
+
+## 6. Criterios de aceptación
+
+- [x] `AC-01` Una puja válida genera exactamente una notificación `bid_received` no leída para el vendedor.
+- [x] `AC-02` Una puja inválida no genera aviso para el vendedor.
+- [x] `AC-03` La campana y Mi actividad muestran «Nueva puja» con enlace a la subasta.
+- [x] `AC-04` SQL, pruebas focalizadas, build y comprobación de specs finalizan correctamente.
+
+## 7. Experiencia y estados
+
+- **Estados normales:** La campana muestra «Nueva puja» y el artículo; Mi actividad mantiene su badge en Mis anuncios.
+- **Estados vacíos:** Sin pujas no se añade ningún badge.
+- **Mensajes y accesibilidad:** El enlace describe el artículo asociado.
+
+## 8. Datos, API, seguridad y operación
+
+- **Datos/modelo:** La restricción de tipos de `lp_notifications` incorpora `bid_received`.
+- **API/integraciones:** Sin rutas nuevas; las rutas de actividad y campana devuelven el tipo existente.
+- **Autorización y privacidad:** La función SQL fija como destinatario al `seller_id` bloqueado de la subasta.
+
+## 9. Plan de validación
+
+| Comprobación | Resultado esperado | Evidencia | Fecha |
+|---|---|---|---|
+| SQL de pujas | Aviso único para puja válida y ninguno para inválida | Migración aplicada en Supabase; consulta transaccional `PASS LP-FEAT-011` | 2026-09-10 |
+| Interfaz | Etiqueta de nueva puja visible | `ActivityNotifications` y `HeaderNotifications`: 2 suites, 3 pruebas superadas | 2026-09-10 |
+| Build y specs | Comprobaciones correctas | `npm run build` y `npm run specs:check` correctos | 2026-09-10 |
+
+## 10. Decisiones, riesgos y preguntas abiertas
+
+- **Decisiones:** Se conserva una novedad por puja para ofrecer trazabilidad inmediata en la beta.
+- **Riesgos y límites:** Subastas con mucha actividad pueden acumular avisos; la agrupación queda para una iteración futura.
+- **Preguntas abiertas:** Ninguna.
+
+## 11. Implementación y trazabilidad
+
+- **Archivos o módulos:** `supabase/migrations/202609100002_seller_bid_notifications.sql`, `src/app/my-products/page.tsx`, `src/app/globals.css`, `src/components/__tests__/ActivityNotifications.test.tsx` y `tests/database/marketplace.sql`.
+- **Migraciones/configuración:** `202609100002_seller_bid_notifications.sql`, aplicada en Supabase el 2026-09-10.
+- **Commit o despliegue:** Pendiente.
+
+## 12. Historial
+
+| Fecha | Estado | Cambio | Autor/agente |
+|---|---|---|---|
+| 2026-09-10 | `DRAFT` | Creación de la ficha | Codex |
+| 2026-09-10 | `IN_PROGRESS` | Issue #31 creada y rama de implementación asignada | Codex |
+| 2026-09-10 | `VERIFIED` | Migración, transacción, interfaz y compilación validadas | Codex |

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -65,5 +65,6 @@
 .notification-chip-message{background:#e0e7ff;border-color:#c7d2fe;color:#3730a3}
 .notification-chip-sale{background:#ecfdf5;border-color:#a7f3d0;color:#065f46}
 .notification-chip-outbid{background:#fee2e2;border-color:#fecaca;color:#991b1b}
+.notification-chip-bid{background:#eff6ff;border-color:#bfdbfe;color:#1d4ed8}
 .notification-chip-status{background:#f3f4f6;border-color:#e5e7eb;color:#1f2937}
 .notification-dot{width:7px;height:7px;border-radius:50%;background:currentColor;display:inline-block}

--- a/src/app/my-products/page.tsx
+++ b/src/app/my-products/page.tsx
@@ -272,6 +272,8 @@ export default function Activity() {
                 ? 'notification-chip notification-chip-sale'
                 : firstNote.type === 'outbid'
                 ? 'notification-chip notification-chip-outbid'
+                : firstNote.type === 'bid_received'
+                ? 'notification-chip notification-chip-bid'
                 : 'notification-chip notification-chip-status'
               : '';
 

--- a/src/components/__tests__/ActivityNotifications.test.tsx
+++ b/src/components/__tests__/ActivityNotifications.test.tsx
@@ -104,6 +104,13 @@ describe('Activity Badges and Notifications (LP-FEAT-009)', () => {
           title: 'Puja superada',
           read: false,
         },
+        {
+          id: 'note-4',
+          listing_id: 'listing-1',
+          type: 'bid_received',
+          title: 'Nueva puja',
+          read: false,
+        },
       ],
     };
 
@@ -144,6 +151,12 @@ describe('Activity Badges and Notifications (LP-FEAT-009)', () => {
     await waitFor(() => {
       expect(screen.getByText('Reloj Vintage')).toBeInTheDocument();
       expect(screen.getByText('Puja superada')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Mis anuncios'));
+    await waitFor(() => {
+      expect(screen.getByText('Bicicleta de montaña')).toBeInTheDocument();
+      expect(screen.getByText('Nueva puja')).toBeInTheDocument();
     });
   });
 });

--- a/supabase/migrations/202609100002_seller_bid_notifications.sql
+++ b/supabase/migrations/202609100002_seller_bid_notifications.sql
@@ -1,0 +1,35 @@
+begin;
+
+alter table public.lp_notifications drop constraint if exists lp_notifications_type_check;
+alter table public.lp_notifications add constraint lp_notifications_type_check check(type in (
+  'order_created', 'new_message', 'outbid', 'status_changed', 'auction_won',
+  'auction_sold', 'auction_ended', 'payment_confirmed', 'reservation_expired', 'bid_received'
+));
+
+create or replace function public.lp_bid(p_listing uuid,p_actor uuid,p_amount integer) returns public.lp_listings language plpgsql security definer set search_path=public as $$
+declare l public.lp_listings; minimum integer; previous_bidder uuid;
+begin
+ select * into l from lp_listings where id=p_listing for update;
+ if not found then raise exception 'Artículo no encontrado'; end if;
+ if l.mode<>'auction' or l.status<>'available' or l.ends_at<=now() then raise exception 'Subasta cerrada'; end if;
+ if l.seller_id=p_actor then raise exception 'No puedes pujar en tu subasta'; end if;
+ previous_bidder := l.highest_bidder;
+ minimum:=case when l.bid_count=0 then l.price_cents else l.price_cents+100 end;
+ if p_amount<minimum or p_amount>1000000 then raise exception 'La puja no alcanza el mínimo permitido'; end if;
+ if l.buy_now_cents is not null and p_amount>=l.buy_now_cents then raise exception 'Utiliza Comprar ahora para ese importe'; end if;
+ insert into lp_bids(listing_id,bidder_id,amount_cents) values(p_listing,p_actor,p_amount);
+ update lp_listings set price_cents=p_amount,bid_count=bid_count+1,highest_bidder=p_actor,
+ ends_at=case when ends_at<now()+interval '2 minutes' then now()+interval '2 minutes' else ends_at end where id=p_listing returning * into l;
+ if previous_bidder is not null and previous_bidder <> p_actor then
+   insert into public.lp_notifications(user_id,listing_id,type,title,body)
+   values(previous_bidder,l.id,'outbid','Puja superada','Otro usuario ha realizado una puja superior en este artículo.');
+ end if;
+ insert into public.lp_notifications(user_id,listing_id,type,title,body)
+ values(l.seller_id,l.id,'bid_received','Nueva puja','Un usuario ha realizado una puja válida en tu subasta.');
+ return l;
+end $$;
+
+revoke execute on function public.lp_bid(uuid,uuid,integer) from public,anon,authenticated;
+grant execute on function public.lp_bid(uuid,uuid,integer) to service_role;
+
+commit;

--- a/tests/database/marketplace.sql
+++ b/tests/database/marketplace.sql
@@ -44,6 +44,7 @@ begin
  insert into public.lp_listings(seller_id,title,description,category,condition,location,images,mode,price_cents,delivery,ends_at) values(seller,'Subasta de prueba','Descripción completa de una subasta sintética para validación.','Hogar','Buen estado','Madrid',array['https://example.invalid/test.jpg'],'auction',1000,'pickup',now()+interval '60 seconds') returning id into auction;
  blocked:=false;begin perform lp_bid(auction,seller,1100);exception when others then blocked:=true;end;if not blocked then raise exception 'FAIL self bid';end if;
  l:=lp_bid(auction,buyer,1000);if l.ends_at<now()+interval '119 seconds' then raise exception 'FAIL anti sniping';end if;
+ if not exists(select 1 from lp_notifications where user_id=seller and listing_id=auction and type='bid_received' and read=false) then raise exception 'FAIL seller bid notification'; end if;
  blocked:=false;begin perform lp_bid(auction,outsider,1001);exception when others then blocked:=true;end;if not blocked then raise exception 'FAIL minimum increment';end if;
  perform lp_bid(auction,outsider,1100);
  if not exists(select 1 from lp_notifications where user_id=buyer and listing_id=auction and type='outbid' and read=false) then raise exception 'FAIL outbid notification'; end if;


### PR DESCRIPTION
Closes #31

Spec: `specs/LP-FEAT-011-aviso-pujas-vendedor.md`

Cada puja válida crea un aviso persistente `bid_received` para el vendedor, visible en campana y Mi actividad con enlace a la subasta.

Evidencia: migración aplicada en Supabase y `PASS LP-FEAT-011`; pruebas focalizadas, build y specs correctos.

`PROJECT_CONTEXT.md` actualizado.