### PR TITLE
[LP-FIX-005] Marcar como leídas las novedades abiertas

### DIFF
--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -235,6 +235,7 @@ El bucket `product-images` es público porque contiene fotografías de anuncios.
 | `GET /api/market/questions/:id` | Público | Preguntas y respuestas paginadas (10 por página) |
 | `GET /api/market/activity` | Autenticado | Compras, ventas, pujas, anuncios, preguntas y notificaciones no leídas |
 | `GET /api/market/notifications` | Autenticado | Contador y lista de notificaciones no leídas con contexto de artículo y pedido para la campana de cabecera |
+| `POST /api/market/mark-notification-read/:id` | Destinatario autenticado | Marcar una novedad concreta como leída |
 | `GET /api/market/order/:id` | Partes del pedido | Pedido, mensajes y datos autorizados (marca notificaciones de la orden como leídas) |
 | `POST /api/market/upload` | Autenticado | Subir una fotografía validada |
 | `POST /api/market/publish` | Autenticado | Crear un anuncio |

--- a/SPEC_REGISTRY.md
+++ b/SPEC_REGISTRY.md
@@ -66,6 +66,7 @@ Prioridades: `P0` bloquea una operación esencial o implica un riesgo grave; `P1
 | `LP-FIX-003` | `FIX` | Entrega fiable de novedades en la campana | `VERIFIED` | `P1` | 2026-09-10 | [Abrir ficha](specs/LP-FIX-003-panel-notificaciones.md) |
 | `LP-FEAT-011` | `FEATURE` | Aviso de nuevas pujas al vendedor | `VERIFIED` | `P1` | 2026-09-10 | [Abrir ficha](specs/LP-FEAT-011-aviso-pujas-vendedor.md) |
 | `LP-FIX-004` | `FIX` | Ruta correcta para la campana de notificaciones | `VERIFIED` | `P0` | 2026-09-11 | [Abrir ficha](specs/LP-FIX-004-ruta-campana-notificaciones.md) |
+| `LP-FIX-005` | `FIX` | Lectura de notificaciones desde la campana | `VERIFIED` | `P1` | 2026-09-11 | [Abrir ficha](specs/LP-FIX-005-lectura-notificaciones-campana.md) |
 
 
 ## Flujo para una solicitud nueva

--- a/specs/LP-FIX-005-lectura-notificaciones-campana.md
+++ b/specs/LP-FIX-005-lectura-notificaciones-campana.md
@@ -97,7 +97,7 @@ Al abrir una novedad desde la campana, esa novedad se marca como leída, desapar
 
 - **Archivos o módulos:** `src/components/Header.tsx`, `src/controllers/marketplace.ts`, pruebas de cabecera.
 - **Migraciones/configuración:** No aplica.
-- **Commit o despliegue:** `f3f0da7` · [PR #39](https://github.com/jorgeluquerubia/lapela/pull/39) preparada para `main`.
+- **Commit o despliegue:** [PR #39](https://github.com/jorgeluquerubia/lapela/pull/39) preparada para `main`.
 
 ## 12. Historial
 

--- a/specs/LP-FIX-005-lectura-notificaciones-campana.md
+++ b/specs/LP-FIX-005-lectura-notificaciones-campana.md
@@ -1,0 +1,109 @@
+---
+id: LP-FIX-005
+type: FIX
+status: VERIFIED
+priority: P1
+requested_at: 2026-09-11
+requested_by: usuario
+source: conversación
+owner: producto
+github_issue: https://github.com/jorgeluquerubia/lapela/issues/37
+related_specs: [LP-FEAT-010, LP-FIX-003, LP-FIX-004]
+dependencies: []
+cross_cutting_concerns: [notificaciones, api, navegación]
+---
+
+# LP-FIX-005 · Lectura de notificaciones desde la campana
+
+## 1. Solicitud original
+
+> "ya sí sale, pero cuando abro las notificaciones y pincho en alguna de ellas, no se quita la notificación, sigue el numero en la campanita"
+
+## 2. Contexto y problema
+
+- **Problema u oportunidad:** La cabecera muestra novedades no leídas, pero sus enlaces solo cierran el panel y navegan. No se registra que la persona haya abierto la novedad, por lo que reaparece y el contador no baja.
+- **Personas afectadas:** Personas autenticadas que abren una novedad de artículo, pedido o chat desde la campana.
+- **Impacto actual:** El contador deja de representar novedades pendientes y obliga a la persona a interpretar como no leídas novedades ya consultadas.
+- **Evidencia disponible:** Revisión de `Header.tsx`: los manejadores de enlace solo ejecutan `setOpen(false)`.
+
+## 3. Resultado esperado
+
+Al abrir una novedad desde la campana, esa novedad se marca como leída, desaparece del panel y el contador disminuye de inmediato antes de llevar a la persona al artículo o al chat relacionado.
+
+## 4. Alcance
+
+### Incluido
+
+- Endpoint autenticado para marcar una novedad concreta como leída solo para su destinatario.
+- Actualización optimista y navegación tras confirmar la operación desde cualquiera de los enlaces de una novedad.
+- Pruebas del endpoint solicitado, el contador y la navegación.
+
+### Excluido
+
+- Marcar todas las novedades como leídas de una vez.
+- Cambios en la creación, tipos o retención de notificaciones.
+
+## 5. Requisitos y reglas de negocio
+
+### Requisitos funcionales
+
+- `RF-01`: Al pulsar una novedad o cualquiera de sus destinos, el cliente debe solicitar marcar como leída exactamente esa notificación.
+- `RF-02`: Tras una respuesta correcta, la novedad debe desaparecer del panel y el distintivo debe disminuir sin esperar al sondeo periódico.
+- `RF-03`: La navegación al artículo, pedido o chat debe conservarse después de la lectura.
+
+### Requisitos no funcionales
+
+- `RNF-01`: La API debe impedir marcar como leída una notificación perteneciente a otra persona usuaria.
+
+### Reglas de negocio
+
+- `RN-01`: Solo la persona destinataria puede modificar el estado de lectura de su notificación.
+- `RN-02`: La lectura de una novedad no debe marcar otras novedades del mismo artículo o pedido.
+
+## 6. Criterios de aceptación
+
+- [x] `AC-01` Al abrir una notificación de chat, pedido o artículo, deja de figurar como no leída y el contador se reduce.
+- [x] `AC-02` La solicitud de lectura identifica la notificación concreta y requiere sesión autenticada.
+- [x] `AC-03` Los enlaces continúan llevando al artículo o al chat/pedido correspondiente.
+- [x] `AC-04` Pruebas focalizadas, build y `npm run specs:check` correctos.
+
+## 7. Experiencia y estados
+
+- **Estados normales:** El panel se cierra y el distintivo se actualiza antes de mostrar el destino.
+- **Estados de error o vacío:** Si la lectura falla, se mantiene la novedad en el panel al refrescar la cabecera; la persona puede seguir entrando en el destino.
+- **Mensajes y accesibilidad:** Se conservan los nombres accesibles y el comportamiento nativo de enlaces.
+
+## 8. Datos, API, seguridad y operación
+
+- **Datos/modelo:** Actualización de `read` y `read_at` en la fila ya existente de `lp_notifications`.
+- **API/integraciones:** `POST /api/market/mark-notification-read/:id`.
+- **Autorización y privacidad:** El controlador restringe la actualización por `id` y `user_id` autenticado.
+- **Migración/rollback:** No requiere migración; el endpoint es aditivo.
+
+## 9. Plan de validación
+
+| Comprobación | Resultado esperado | Evidencia | Fecha |
+|---|---|---|---|
+| Prueba de cabecera | Marca una fila concreta, actualiza distintivo y navega | `HeaderNotifications` (3 pruebas) correcto | 2026-09-11 |
+| Build y gobernanza | Comprobaciones correctas | `npm run build` con configuración pública simulada y `npm run specs:check` correctos | 2026-09-11 |
+
+## 10. Decisiones, riesgos y preguntas abiertas
+
+- **Decisiones:** Se marca la fila concreta, no todas las notificaciones del artículo o pedido, para no ocultar novedades independientes.
+- **Riesgos y límites:** Una interrupción de red puede impedir la confirmación antes de navegar; la pantalla de destino conserva sus marcados contextuales y el siguiente sondeo refleja el estado real.
+- **Preguntas abiertas:** Ninguna.
+
+## 11. Implementación y trazabilidad
+
+- **Archivos o módulos:** `src/components/Header.tsx`, `src/controllers/marketplace.ts`, pruebas de cabecera.
+- **Migraciones/configuración:** No aplica.
+- **Commit o despliegue:** `f3f0da7` · [PR #39](https://github.com/jorgeluquerubia/lapela/pull/39) preparada para `main`.
+
+## 12. Historial
+
+| Fecha | Estado | Cambio | Autor/agente |
+|---|---|---|---|
+| 2026-09-11 | `DRAFT` | Ficha creada tras detectar la ausencia de marcado desde la campana | Codex |
+| 2026-09-11 | `IN_PROGRESS` | Issue #37 creada y rama de corrección asignada | Codex |
+| 2026-09-11 | `VERIFIED` | Lectura individual, contador optimista, navegación y pruebas verificados | Codex |
+| 2026-09-11 | `VERIFIED` | PR #39 preparada contra `main` | Codex |

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -33,6 +33,19 @@ export default function Header(){
     return()=>window.removeEventListener('keydown',onKeyDown);
   },[]);
 
+  const openNotification=async(event:React.MouseEvent<HTMLAnchorElement>,notification:any,href:string)=>{
+    event.preventDefault();
+    setOpen(false);
+    try{
+      const response=await fetch('/api/market/mark-notification-read/'+notification.id,{method:'POST',headers:{'Content-Type':'application/json'},body:'{}'});
+      if(response.ok){
+        setNotifications(current=>current.filter(item=>item.id!==notification.id));
+        setUnreadCount(current=>Math.max(0,current-1));
+      }
+    }catch{}
+    router.push(href);
+  };
+
   return <header className="site-header">
     <div className="header-inner">
       <Brand/>
@@ -49,11 +62,11 @@ export default function Header(){
           </button>
           {open&&<section id="notification-panel" className="notification-panel" aria-label="Novedades">
             <div className="notification-panel-heading"><strong>Novedades</strong><Link href="/my-products" onClick={()=>setOpen(false)}>Ver actividad</Link></div>
-            {!notifications.length?<p className="notification-empty">No tienes novedades pendientes.</p>:<ul>{notifications.map(notification=><li key={notification.id}>
-              <Link href={notificationArticleHref(notification)} onClick={()=>setOpen(false)} className="notification-article-link"><strong>{notification.title}</strong><span>{notification.listing?.title||'Ver artículo'}</span></Link>
+            {!notifications.length?<p className="notification-empty">No tienes novedades pendientes.</p>:<ul>{notifications.map(notification=>{const articleHref=notificationArticleHref(notification);const orderHref='/orders/'+notification.order_id;return <li key={notification.id}>
+              <Link href={articleHref} onClick={event=>openNotification(event,notification,articleHref)} className="notification-article-link"><strong>{notification.title}</strong><span>{notification.listing?.title||'Ver artículo'}</span></Link>
               {notification.body&&<p>{notification.body}</p>}
-              <div className="notification-actions"><Link href={notificationArticleHref(notification)} onClick={()=>setOpen(false)}>Ver artículo</Link>{notification.order_id&&<Link href={'/orders/'+notification.order_id} onClick={()=>setOpen(false)}>{notification.type==='new_message'?'Abrir chat':'Ver pedido'}</Link>}</div>
-            </li>)}</ul>}
+              <div className="notification-actions"><Link href={articleHref} onClick={event=>openNotification(event,notification,articleHref)}>Ver artículo</Link>{notification.order_id&&<Link href={orderHref} onClick={event=>openNotification(event,notification,orderHref)}>{notification.type==='new_message'?'Abrir chat':'Ver pedido'}</Link>}</div>
+            </li>})}</ul>}
           </section>}
         </div>}
         <Link href="/my-products" className="account-link">{user?'Mi actividad':'Mis compras'}</Link>

--- a/src/components/__tests__/HeaderNotifications.test.tsx
+++ b/src/components/__tests__/HeaderNotifications.test.tsx
@@ -4,12 +4,14 @@ import {useAuth} from '@/context/AuthContext';
 
 jest.mock('@/context/AuthContext',()=>({useAuth:jest.fn()}));
 jest.mock('next/link',()=>({__esModule:true,default:({children,href,onClick,className}:any)=><a href={href} onClick={onClick} className={className}>{children}</a>}));
-jest.mock('next/navigation',()=>({useRouter:()=>({push:jest.fn()})}));
+const push=jest.fn();
+jest.mock('next/navigation',()=>({useRouter:()=>({push})}));
 
 describe('Header notifications',()=>{
   beforeEach(()=>{
+    push.mockReset();
     (useAuth as jest.Mock).mockReturnValue({user:{id:'user-1'},loading:false});
-    global.fetch=jest.fn().mockResolvedValue({json:()=>Promise.resolve({
+    global.fetch=jest.fn().mockResolvedValue({ok:true,json:()=>Promise.resolve({
       unreadCount:2,
       notifications:[{
         id:'note-1',listing_id:'123e4567-e89b-12d3-a456-426614174000',order_id:'order-1',type:'new_message',title:'Nuevo mensaje',body:'¿Sigue disponible?',listing:{title:'Cámara de prueba'}
@@ -30,7 +32,7 @@ describe('Header notifications',()=>{
   });
 
   it('keeps the unread notification visible when article metadata is unavailable',async()=>{
-    global.fetch=jest.fn().mockResolvedValue({json:()=>Promise.resolve({
+    global.fetch=jest.fn().mockResolvedValue({ok:true,json:()=>Promise.resolve({
       unreadCount:1,
       notifications:[{id:'note-without-listing',listing_id:'123e4567-e89b-12d3-a456-426614174000',type:'new_message',title:'Nuevo mensaje'}]
     })});
@@ -38,5 +40,16 @@ describe('Header notifications',()=>{
     fireEvent.click(await screen.findByRole('button',{name:'1 novedades sin leer'}));
     expect(await screen.findByText('Nuevo mensaje')).toBeInTheDocument();
     expect(screen.getAllByRole('link',{name:'Ver artículo'})[0]).toHaveAttribute('href','/articulos/articulo-123e4567-e89b-12d3-a456-426614174000');
+  });
+
+  it('marks only the opened notification as read, updates the badge and then opens its chat',async()=>{
+    render(<Header/>);
+    fireEvent.click(await screen.findByRole('button',{name:'2 novedades sin leer'}));
+    fireEvent.click(await screen.findByRole('link',{name:'Abrir chat'}));
+    await waitFor(()=>expect(global.fetch).toHaveBeenCalledWith('/api/market/mark-notification-read/note-1',{
+      method:'POST',headers:{'Content-Type':'application/json'},body:'{}'
+    }));
+    await waitFor(()=>expect(screen.getByRole('button',{name:'1 novedades sin leer'})).toBeInTheDocument());
+    expect(push).toHaveBeenCalledWith('/orders/order-1');
   });
 });

--- a/src/controllers/marketplace.ts
+++ b/src/controllers/marketplace.ts
@@ -92,6 +92,10 @@ export async function handle(request:Request,path:string[]){try{
   const updated=await rpc('lp_answer_question',{p_question_id:id,p_actor:user.id,p_answer:ans});
   return ok(updated);
  }
+ if(action==='mark-notification-read'&&uuid(id||'')){
+  const updated=await result(db.from('lp_notifications').update({read:true,read_at:new Date().toISOString()}).eq('id',id).eq('user_id',user.id).eq('read',false).select('id'));
+  return ok({success:true,marked:updated.length>0});
+ }
   if(action==='mark-listing-read'&&targetId&&uuid(targetId)){
    await rpc('lp_mark_listing_notifications_read',{p_listing:targetId,p_actor:user.id});
    return ok({success:true});


### PR DESCRIPTION
## Resumen
- Marca exactamente la novedad pulsada antes de abrir su artículo, pedido o chat.
- Actualiza el panel y el contador de la campana sin esperar al sondeo.
- Restringe la actualización al destinatario autenticado.

Closes #37

## Spec
[LP-FIX-005](specs/LP-FIX-005-lectura-notificaciones-campana.md)

## Evidencia
- `npm test -- --runInBand src/components/__tests__/HeaderNotifications.test.tsx` (3 correctas)
- `npm run build` con configuración pública simulada (correcto)
- `npm run specs:check` (correcto)

`PROJECT_CONTEXT.md` actualizado: sí, se documenta el nuevo endpoint.