### PR TITLE
[LP-FEAT-015] Identidad visual inspirada en la peseta

### DIFF
--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -18,6 +18,7 @@ La propuesta combina la sencillez de uso de un marketplace móvil con dos mecani
 - **Datos:** los anuncios activos están separados por entorno `sandbox` o `live`; la beta consulta `sandbox`.
 - **Cobros reales:** código preparado para Stripe Connect, pero desactivado hasta configurar la cuenta, el webhook, las condiciones legales y la operación de soporte.
 - **Correo:** autenticación por email con confirmación y recuperación; el proyecto todavía usa el proveedor de correo de prueba de Supabase y necesita SMTP propio antes de una apertura pública.
+- **Identidad visual:** la interfaz usa la propuesta `LP-FEAT-015`, una reinterpretación contemporánea de la peseta con sello-moneda, tinta verde, papel marfil y cobre envejecido. La moneda operativa sigue siendo el euro.
 
 ## 3. Principios de producto
 

--- a/SPEC_REGISTRY.md
+++ b/SPEC_REGISTRY.md
@@ -69,6 +69,7 @@ Prioridades: `P0` bloquea una operación esencial o implica un riesgo grave; `P1
 | `LP-FIX-004` | `FIX` | Ruta correcta para la campana de notificaciones | `VERIFIED` | `P0` | 2026-09-11 | [Abrir ficha](specs/LP-FIX-004-ruta-campana-notificaciones.md) |
 | `LP-FEAT-012` | `FEATURE` | Escalado y centrado de imágenes en anuncios | `VERIFIED` | `P2` | 2026-09-11 | [Abrir ficha](specs/LP-FEAT-012-imagenes-centradas.md) |
 | `LP-FIX-005` | `FIX` | Lectura de notificaciones desde la campana | `VERIFIED` | `P1` | 2026-09-11 | [Abrir ficha](specs/LP-FIX-005-lectura-notificaciones-campana.md) |
+| `LP-FEAT-015` | `FEATURE` | Identidad visual inspirada en la peseta | `IMPLEMENTED` | `P2` | 2026-09-12 | [Abrir ficha](specs/LP-FEAT-015-identidad-visual-peseta.md) |
 
 
 ## Flujo para una solicitud nueva

--- a/specs/LP-FEAT-015-identidad-visual-peseta.md
+++ b/specs/LP-FEAT-015-identidad-visual-peseta.md
@@ -1,0 +1,123 @@
+---
+id: LP-FEAT-015
+type: FEATURE
+status: IMPLEMENTED
+priority: P2
+requested_at: 2026-09-12
+requested_by: usuario
+source: conversación
+owner: producto
+github_issue: https://github.com/jorgeluquerubia/lapela/issues/43
+related_specs: [LP-FEAT-001, LP-FEAT-008]
+dependencies: [Next.js, CSS global]
+cross_cutting_concerns: [DOC, ACC]
+---
+
+# LP-FEAT-015 · Identidad visual inspirada en la peseta
+
+## 1. Solicitud original
+
+> me gustaria darle un lavado de cara al diseño para que en cierta manera se asocie a "la pela" con una peseta. Quiero que la pagina transmita nostalgia por las pesetas de algun modo, entonces habría que cambiar el logo por algo que recuerde a una peseta pero modernizado. Puedes inventar un diseño chulo para esto? los colores de la pagina tambien tienen que acompañar al logo y a esa idea.
+
+## 2. Contexto y problema
+
+- **Problema u oportunidad:** La interfaz beta tiene una identidad funcional y limpia, pero el logotipo actual no conecta visualmente con el doble sentido de La Pela y la peseta. Falta un sistema reconocible que una nostalgia española y marketplace contemporáneo.
+- **Personas afectadas:** Personas que exploran, compran o venden en La Pela, especialmente quienes reconocen la referencia cultural a la peseta.
+- **Impacto actual:** La marca resulta genérica y el recuerdo de producto, navegación y estados no se apoya en una personalidad propia.
+- **Evidencia disponible:** La marca actual usa un círculo con las letras `lp` y una flecha; la paleta se limita a verde, blanco y lima.
+
+## 3. Resultado esperado
+
+La aplicación debe presentar una identidad visual renovada y coherente: una marca con forma de moneda de peseta reinterpretada, colores de tinta y papel con cobre como acento, y una portada/navegación/catalogo que evoquen coleccionismo y segunda mano sin parecer una recreación antigua.
+
+## 4. Alcance
+
+### Incluido
+
+- Nuevo componente de marca accesible y responsive, construido como SVG inline sin depender de imágenes externas.
+- Revisión de variables cromáticas, tipografía del sistema, bordes, sombras y superficies.
+- Tratamiento visual de cabecera, navegación, banner beta, hero, filtros, tarjetas, etiquetas, botones, estados vacíos/carga y pie.
+- Detalles de nostalgia discretos: textura CSS, sello de fecha, nomenclatura editorial y acentos de cobre.
+- Compatibilidad responsive y foco visible.
+
+### Excluido
+
+- Cambios en modelos, API, navegación, reglas de compra o comportamiento transaccional.
+- Uso de imágenes o fuentes remotas que añadan dependencias de red.
+- Rediseño funcional de las pantallas de checkout, autenticación o chat más allá de los estilos globales.
+
+## 5. Requisitos y reglas de negocio
+
+### Requisitos funcionales
+
+- `RF-01`: La cabecera y el pie deben mostrar una marca inspirada en una moneda, con el nombre La Pela y una descripción accesible.
+- `RF-02`: La interfaz pública debe usar una paleta coherente de tinta verde, papel marfil y cobre envejecido, manteniendo la semántica del precio y la subasta.
+- `RF-03`: La portada debe comunicar el concepto de marca con un hero editorial y un indicador visual de moneda/coleccionismo.
+- `RF-04`: Las tarjetas de artículo, controles de navegación, filtros y estados deben compartir el nuevo lenguaje visual sin cambiar sus enlaces ni acciones.
+
+### Requisitos no funcionales
+
+- `RNF-01`: El logotipo no debe depender de un recurso externo y debe conservar nitidez a cualquier escala.
+- `RNF-02`: El contraste de texto y controles debe seguir siendo legible en escritorio y móvil; los estados de foco deben mantenerse visibles.
+- `RNF-03`: La implementación debe conservar el comportamiento responsive existente y no añadir una dependencia de runtime.
+
+### Reglas de negocio
+
+- `RN-01`: La nostalgia es únicamente expresiva; no debe sugerir que la aplicación usa pesetas como moneda de pago. Los precios continúan mostrándose en euros.
+- `RN-02`: La indicación de beta y pagos simulados debe seguir siendo visible y distinguible.
+
+## 6. Criterios de aceptación
+
+- [ ] `AC-01` La cabecera y el pie muestran el nuevo sello-moneda y el texto “la pela.” sin romper sus enlaces accesibles.
+- [ ] `AC-02` La portada usa la nueva paleta y comunica el concepto con un hero visible, una textura sutil y un acento editorial relacionado con la peseta.
+- [ ] `AC-03` Los controles, tarjetas, etiquetas y estados principales presentan estilos coherentes con la nueva identidad y conservan sus acciones actuales.
+- [ ] `AC-04` En viewport móvil la cabecera, búsqueda, navegación y catálogo siguen siendo utilizables sin desbordamiento horizontal no intencionado.
+- [ ] `AC-05` El logotipo es SVG inline, no carga recursos remotos y dispone de nombre accesible mediante la marca enlazada.
+- [ ] `AC-06` `npm run specs:check`, las pruebas frontend y `npm run build` terminan sin errores.
+
+## 7. Experiencia y estados
+
+- **Estados normales:** La moneda funciona como firma de marca; el cobre se reserva para acentos, la tinta para acciones y el papel para superficies cálidas.
+- **Estados de error o vacío:** Conservan la jerarquía visual y usan colores semánticos legibles, sin perder el tono editorial.
+- **Mensajes y accesibilidad:** El SVG es decorativo dentro del enlace con `aria-label`; no se usa como único indicador de estado.
+- **Responsive o canales afectados:** Cabecera en dos filas en móvil; hero y rejilla de artículos adaptables; se mantienen foco visible y controles táctiles.
+
+## 8. Datos, API, seguridad y operación
+
+- **Datos/modelo:** Sin cambios.
+- **API/integraciones:** Sin cambios.
+- **Autorización y privacidad:** Sin cambios.
+- **Observabilidad y soporte:** No aplica.
+- **Métricas o señales de éxito:** Validación visual en escritorio y móvil, junto con las comprobaciones de build y tests.
+- **Migración/rollback:** Revertir los archivos de presentación de la spec restaura el sistema visual previo; no hay migración de datos.
+
+## 9. Plan de validación
+
+| Comprobación | Resultado esperado | Evidencia | Fecha |
+|---|---|---|---|
+| `npm run specs:check` | Ficha y registro válidos | `Specs válidas: 25 fichas registradas y 36 documentos enlazados.` | 2026-09-12 |
+| Pruebas frontend dirigidas | Componentes de cabecera y tarjetas sin regresiones | `PASS`: 2 suites, 3 tests (`Header.test.tsx`, `ProductCard.test.tsx`) | 2026-09-12 |
+| Pruebas frontend completas | Suite existente sin regresiones | Pendiente: la suite actual falla en expectativas legacy de `search` y en `tests-examples/demo-todo-app.spec.ts`; no relacionado con esta spec | 2026-09-12 |
+| `npm run build` | Compilación completa sin errores | `PASS`: 26 páginas generadas; tipos, lint y trazas completados | 2026-09-12 |
+| Revisión visual responsive | Sello SVG, paleta y hero aplicados; móvil sin overflow horizontal (`bodyWidth=604`, `contentWidth=604`) | Preview local en `http://localhost:3015/` | 2026-09-12 |
+
+## 10. Decisiones, riesgos y preguntas abiertas
+
+- **Decisiones:** Usar SVG inline para el sello; la referencia se construye con borde circular, muescas y “LP”, evitando una copia literal de una moneda histórica. Mantener euros como moneda única.
+- **Riesgos y límites:** Una textura demasiado intensa puede reducir legibilidad; se limitará a fondos con opacidad baja y no se aplicará sobre texto.
+- **Preguntas abiertas:** Ninguna bloqueante para esta primera propuesta.
+
+## 11. Implementación y trazabilidad
+
+- **Archivos o módulos:** `src/components/Brand.tsx`, `src/components/Catalog.tsx`, `src/app/globals.css`, `src/app/layout.tsx`.
+- **Migraciones/configuración:** No aplica.
+- **Commit o despliegue:** Pendiente de commit y pull request.
+- **Rama:** `codex/lp-feat-015-identidad-peseta`.
+- **Issue:** `https://github.com/jorgeluquerubia/lapela/issues/43`.
+
+## 12. Historial
+
+| Fecha | Estado | Cambio | Autor/agente |
+|---|---|---|---|
+| 2026-09-12 | `IN_PROGRESS` | Creación de la ficha y definición de dirección visual | Codex |
+| 2026-09-12 | `IMPLEMENTED` | Nuevo sello SVG, hero editorial, paleta y estilos globales aplicados; build y revisión visual superados | Codex |

--- a/specs/LP-FEAT-015-identidad-visual-peseta.md
+++ b/specs/LP-FEAT-015-identidad-visual-peseta.md
@@ -111,9 +111,10 @@ La aplicación debe presentar una identidad visual renovada y coherente: una mar
 
 - **Archivos o módulos:** `src/components/Brand.tsx`, `src/components/Catalog.tsx`, `src/app/globals.css`, `src/app/layout.tsx`.
 - **Migraciones/configuración:** No aplica.
-- **Commit o despliegue:** Pendiente de commit y pull request.
+- **Commit o despliegue:** `e4143ad` · Pull request `https://github.com/jorgeluquerubia/lapela/pull/44`.
 - **Rama:** `codex/lp-feat-015-identidad-peseta`.
 - **Issue:** `https://github.com/jorgeluquerubia/lapela/issues/43`.
+- **Pull request:** `https://github.com/jorgeluquerubia/lapela/pull/44`.
 
 ## 12. Historial
 
@@ -121,3 +122,4 @@ La aplicación debe presentar una identidad visual renovada y coherente: una mar
 |---|---|---|---|
 | 2026-09-12 | `IN_PROGRESS` | Creación de la ficha y definición de dirección visual | Codex |
 | 2026-09-12 | `IMPLEMENTED` | Nuevo sello SVG, hero editorial, paleta y estilos globales aplicados; build y revisión visual superados | Codex |
+| 2026-09-12 | `IMPLEMENTED` | PR #44 preparada hacia `main`; queda pendiente resolver los fallos legacy de la suite frontend para marcar `VERIFIED` | Codex |

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -79,3 +79,123 @@
 .notification-dot{width:7px;height:7px;border-radius:50%;background:currentColor;display:inline-block}
 .profile-link{color:var(--green);font-weight:700;text-decoration:underline;text-underline-offset:2px}.product-seller{display:inline-block;margin-top:9px;font-size:12px}.detail-seller{display:inline-block;margin:2px 0 15px}.bid-history{margin-top:24px;border-top:1px solid var(--line);padding-top:22px}.bid-history h2{font-size:20px}.bid-row{display:grid;grid-template-columns:1fr auto;gap:4px 14px;align-items:center;padding:10px 0;border-bottom:1px solid var(--line);font-size:14px}.bid-row small{grid-column:1/-1;color:var(--muted)}.public-profile{max-width:1080px;margin:20px auto}.profile-heading{display:flex;justify-content:space-between;align-items:end;gap:20px;margin-bottom:24px}.profile-heading h1{margin-bottom:6px}.profile-stats{display:grid;grid-template-columns:repeat(3,1fr);gap:14px;margin-bottom:35px}.profile-stats>div{padding:20px;border:1px solid var(--line);border-radius:13px;background:var(--surface)}.profile-stats strong{display:block;font-size:28px;letter-spacing:-1px}.profile-stats span{font-size:13px;color:var(--muted)}.profile-section{margin:35px 0}.review-list{display:grid;gap:12px}.review-card{border:1px solid var(--line);border-radius:12px;padding:15px;background:white}.review-card>div{display:flex;justify-content:space-between;gap:12px;align-items:center}.review-card p{margin:10px 0 0}.review-card small{color:var(--muted);font-size:12px}.review-stars{color:#b58a00;letter-spacing:1px;white-space:nowrap}.order-counterparts{display:flex;gap:16px;flex-wrap:wrap;margin:-10px 0 22px;font-size:14px}.order-reviews{border-top:1px solid var(--line);margin-top:25px;padding-top:22px}.order-reviews .field-input{margin-bottom:12px}
 @media(max-width:650px){.profile-heading{align-items:start;flex-direction:column}.profile-stats{grid-template-columns:1fr}.bid-row{grid-template-columns:1fr auto}.order-counterparts{flex-direction:column;gap:5px}}
+
+/* LP-FEAT-015: La Pela, una peseta reinterpretada en clave editorial. */
+:root{
+  --ink:#20352c;
+  --muted:#6d766e;
+  --green:#145c45;
+  --green-dark:#0d3e30;
+  --green-soft:#dce8d8;
+  --lime:#e7eea5;
+  --paper:#f8f4ea;
+  --paper-deep:#eee6d5;
+  --surface:#f1ede3;
+  --copper:#a96038;
+  --copper-soft:#e7c3a9;
+  --gold:#d4a855;
+  --line:#ded6c7;
+  --radius:18px;
+}
+
+body{background:var(--paper);color:var(--ink);font-family:Arial,Helvetica,sans-serif;background-image:radial-gradient(circle at 12% 4%,rgba(212,168,85,.08),transparent 26rem),radial-gradient(circle at 92% 48%,rgba(20,92,69,.045),transparent 30rem)}
+h1,h2{font-family:Georgia,'Times New Roman',serif;font-weight:700;letter-spacing:-.045em}
+.site-header{border-bottom:1px solid var(--line);background:rgba(248,244,234,.94);backdrop-filter:blur(10px)}
+.header-inner{padding-top:20px;padding-bottom:18px}
+.brand{gap:11px;font-family:Arial,Helvetica,sans-serif;font-size:29px;letter-spacing:-1.7px;color:var(--green-dark)}
+.brand-mark{width:43px;height:43px;border:0;border-radius:50%;padding:0;background:var(--copper);box-shadow:inset 0 0 0 2px rgba(255,247,224,.64),3px 4px 0 rgba(13,62,48,.14);overflow:visible}
+.brand-mark svg{width:100%;height:100%;overflow:visible}
+.brand-coin-shadow{fill:#754026;opacity:.34;transform:translateY(2px)}
+.brand-coin-face{fill:var(--copper);stroke:#fff1d4;stroke-width:1.2}
+.brand-coin-ring{fill:none;stroke:#f3d9ad;stroke-width:1;opacity:.85}
+.brand-coin-spark{fill:none;stroke:#f3d9ad;stroke-width:1.25;stroke-linecap:round;opacity:.9}
+.brand-mark text{fill:#fff1d4;font-family:Georgia,serif;font-weight:700;font-size:17px;letter-spacing:-1px}
+.brand-mark .brand-coin-value{font-size:5px;letter-spacing:.8px;font-family:Arial,sans-serif}
+.brand-wordmark{display:inline-block}
+.brand-dot{color:var(--copper)}
+.global-search{background:#fffdf8;border-color:var(--line);border-radius:999px;box-shadow:0 2px 0 rgba(32,53,44,.025)}
+.global-search:focus-within{border-color:var(--copper);box-shadow:0 0 0 3px rgba(169,96,56,.12)}
+.header-actions{color:#405348}
+.header-actions .account-link:hover{color:var(--copper)}
+.button{border-color:var(--line);border-radius:999px;background:#fffdf8;box-shadow:0 2px 0 rgba(32,53,44,.04);transition:transform .18s ease,box-shadow .18s ease,background .18s ease}
+.button:hover{transform:translateY(-1px);box-shadow:0 5px 14px rgba(32,53,44,.1)}
+.button.primary{background:var(--green);border-color:var(--green);box-shadow:0 3px 0 var(--green-dark);color:#fffdf8}
+.button.primary:hover{background:var(--green-dark);box-shadow:0 4px 0 #082a20}
+.category-nav{color:#53645a;padding-bottom:15px}
+.category-nav a:hover,.category-nav>a:first-child{color:var(--copper)}
+.nav-about{color:var(--green)}
+.nav-separator{background:var(--line)}
+.page-shell{padding-top:38px}
+.site-footer{border-top-color:var(--line);padding-top:38px;background:transparent}
+.site-footer>div:last-child a:hover{color:var(--copper)}
+.site-footer p{color:var(--muted)}
+.market-intro{position:relative;isolation:isolate;overflow:hidden;min-height:265px;margin-bottom:42px;padding:39px 44px;background:var(--green-dark);border:1px solid #0a3528;border-radius:24px;box-shadow:0 15px 35px rgba(13,62,48,.14);background-image:radial-gradient(circle at 73% 50%,rgba(212,168,85,.2),transparent 12rem),linear-gradient(135deg,#0d3e30 0%,#145c45 62%,#236b4e 100%)}
+.market-intro::before{content:"";position:absolute;inset:0;z-index:-1;opacity:.12;pointer-events:none;background-image:radial-gradient(#fff 0.7px,transparent .7px);background-size:7px 7px;mix-blend-mode:soft-light}
+.market-intro::after{content:"";position:absolute;z-index:-1;width:290px;height:290px;right:19%;top:-115px;border:1px solid rgba(241,216,173,.25);border-radius:50%;box-shadow:0 0 0 10px rgba(241,216,173,.06),0 0 0 20px rgba(241,216,173,.035)}
+.market-intro-copy{position:relative;z-index:1}
+.intro-eyebrow{display:block;margin-bottom:16px;color:var(--lime);font-size:11px;font-weight:700;letter-spacing:.16em}
+.market-intro h1{max-width:650px;margin:0 0 15px;font-size:clamp(2rem,4vw,3.4rem);line-height:1.05;letter-spacing:-.055em}
+.market-intro h1 em{color:#f4d89d;font-style:normal}
+.market-intro p{font-size:16px;color:#dae7d9}
+.market-intro-coin{position:relative;z-index:1;display:flex;flex-direction:column;align-items:center;gap:8px;margin:0 2vw 0 auto;transform:rotate(7deg)}
+.intro-coin-face{display:flex;flex-direction:column;align-items:center;justify-content:center;width:155px;height:155px;border-radius:50%;color:#7d482a;background:radial-gradient(circle at 35% 28%,#f0d19a,#c68a51 70%,#96512f);border:4px solid #f2d7a7;box-shadow:inset 0 0 0 5px rgba(112,58,30,.18),8px 12px 0 rgba(4,35,25,.22);font-family:Georgia,serif}
+.intro-coin-face span{font-size:35px;line-height:.9;font-weight:700}
+.intro-coin-face strong{margin-top:7px;font-family:Arial,sans-serif;font-size:12px;letter-spacing:.15em}
+.intro-coin-face small{margin-top:7px;padding-top:5px;border-top:1px solid rgba(125,72,42,.45);font-family:Arial,sans-serif;font-size:9px;letter-spacing:.18em}
+.intro-coin-caption{color:#f0d8a4;font-family:Georgia,serif;font-size:13px;font-style:italic}
+.intro-note{border-left-color:rgba(241,216,173,.36);color:#d5e3d9}
+.intro-note strong{color:var(--lime)}
+.catalog-head{margin-bottom:26px}
+.catalog-head h2{font-size:1.8rem}
+.muted{color:var(--muted)}
+.mode-tabs{border:1px solid var(--line);background:var(--paper-deep);border-radius:999px}
+.mode-tabs button{border-radius:999px}
+.mode-tabs button.active{background:#fffdf8;color:var(--green-dark);box-shadow:0 2px 5px rgba(32,53,44,.1)}
+.filter-panel{border-right-color:var(--line)}
+.filter-panel h3{font-family:Georgia,serif;font-size:15px;color:var(--green-dark)}
+.category-button{border:1px solid transparent;border-radius:999px;color:#6c776e}
+.category-button:hover{background:#f0e9da;color:var(--copper)}
+.category-button.active{background:var(--green-soft);color:var(--green-dark);border-color:#c2d4bd}
+.filter-prices input,.filter-panel select,.filter-panel input.location{background:#fffdf8;border-color:var(--line);border-radius:9px}
+.filter-note{background:var(--paper-deep);border:1px solid #e3d9c6;border-radius:15px}
+.filter-note strong{font-family:Georgia,serif;color:var(--green-dark)}
+.filter-note a,.underline{color:var(--copper);text-underline-offset:3px}
+.catalog-toolbar select{background:transparent}
+.product-card{position:relative}
+.product-image{border-radius:16px;background:#eae3d4;border:1px solid #e1d8c6;box-shadow:0 3px 0 rgba(32,53,44,.05)}
+.product-card:hover .product-image{border-color:#c68a65;box-shadow:0 7px 18px rgba(32,53,44,.11)}
+.product-image img{padding:16px}
+.sale-tag{border:1px solid rgba(32,53,44,.08);border-radius:999px;background:#fffdf8;color:var(--green-dark);box-shadow:0 2px 5px rgba(32,53,44,.08)}
+.sale-tag.auction{background:var(--lime);color:var(--green-dark);border-color:#d1db83}
+.product-info{padding-top:15px}
+.price-row strong{font-family:Georgia,serif;color:var(--green-dark)}
+.price-row span{color:var(--copper);font-weight:700}
+.product-info h3{color:#30463a}
+.product-info h3:hover{color:var(--copper)}
+.product-meta{color:#788176}
+.empty-state{background:rgba(255,253,248,.48);border-color:#d2c7b3}
+.empty-state h3{font-family:Georgia,serif;color:var(--green-dark)}
+.notice{background:#f1edce;border-color:#ded59b;color:#59622c;border-radius:12px}
+.error-message{border-color:#e5c4b7;background:#fff3ed}
+.sandbox-banner{background:#ece8c9;color:#5b6330;border-bottom-color:#dbd19b}
+.brand-spinner-coin{background:#fff5df;border-color:var(--copper);color:var(--copper);box-shadow:0 2px 6px rgba(169,96,56,.15)}
+.brand-spinner-coin::before{content:"";position:absolute;inset:3px;border:1px solid var(--copper-soft);border-radius:50%}
+.brand-spinner-value{position:absolute;top:2px;font-family:Arial,sans-serif;font-size:5px;letter-spacing:.3px;line-height:1}
+.brand-spinner-lp{font-family:Georgia,serif;color:var(--green-dark);font-size:inherit;line-height:1;margin-top:3px}
+.brand-spinner-arrow{display:none}
+
+@media(max-width:900px){.market-intro{padding:34px}.market-intro-coin{margin-right:0}.intro-note{display:none}}
+@media(max-width:650px){
+  .page-shell{padding-top:22px}
+  .header-inner{padding-top:16px;padding-bottom:16px}
+  .brand{font-size:26px}
+  .brand-mark{width:39px;height:39px}
+  .market-intro{min-height:0;padding:27px 24px 25px;border-radius:19px;margin-bottom:30px}
+  .market-intro h1{font-size:clamp(2rem,10vw,2.65rem)}
+  .market-intro-coin{position:absolute;right:-25px;top:73px;opacity:.27;transform:rotate(7deg) scale(.86)}
+  .market-intro-coin .intro-coin-caption{display:none}
+  .market-intro::after{right:-90px;top:-60px}
+  .catalog-head h2{font-size:1.6rem}
+  .mobile-filters{background:#fffdf8}
+  .product-image{border-radius:13px}
+}

--- a/src/components/Brand.tsx
+++ b/src/components/Brand.tsx
@@ -1,2 +1,19 @@
 import Link from 'next/link';
-export default function Brand(){return <Link className="brand" href="/" aria-label="La Pela · Inicio"><span className="brand-mark" aria-hidden="true">lp<span>↗</span></span><span>la pela<span className="brand-dot">.</span></span></Link>}
+
+export default function Brand(){
+  return (
+    <Link className="brand" href="/" aria-label="La Pela · Inicio">
+      <span className="brand-mark" aria-hidden="true">
+        <svg viewBox="0 0 56 56" role="presentation">
+          <circle className="brand-coin-shadow" cx="28" cy="29" r="22" />
+          <circle className="brand-coin-face" cx="28" cy="27" r="22" />
+          <circle className="brand-coin-ring" cx="28" cy="27" r="17.5" />
+          <path className="brand-coin-spark" d="M28 12v4M28 38v4M13 27h4M39 27h4" />
+          <text x="28" y="31.5" textAnchor="middle">lp</text>
+          <text className="brand-coin-value" x="28" y="20.5" textAnchor="middle">1 P</text>
+        </svg>
+      </span>
+      <span className="brand-wordmark">la pela<span className="brand-dot">.</span></span>
+    </Link>
+  );
+}

--- a/src/components/BrandSpinner.tsx
+++ b/src/components/BrandSpinner.tsx
@@ -18,8 +18,8 @@ export default function BrandSpinner({
       className={`brand-spinner ${className}`}
     >
       <div className={`brand-spinner-coin brand-spinner-${size}`} aria-hidden="true">
+        <span className="brand-spinner-value">1 P</span>
         <span className="brand-spinner-lp">lp</span>
-        <span className="brand-spinner-arrow">↗</span>
       </div>
       <span className="sr-only">{label}</span>
     </div>

--- a/src/components/Catalog.tsx
+++ b/src/components/Catalog.tsx
@@ -77,9 +77,14 @@ export default function Catalog({initialCategory, initialMode}: CatalogProps = {
 
   return <>
     <section className="market-intro">
-      <div>
-        <h1>Segunda mano.<br/>Sin segundas negociaciones.</h1>
+      <div className="market-intro-copy">
+        <span className="intro-eyebrow">EL MERCADO DE LAS COSAS BUENAS</span>
+        <h1>Segunda mano.<br/><em>Sin segundas negociaciones.</em></h1>
         <p>Encuentra lo que buscas. Compra a precio cerrado o puja por ello.</p>
+      </div>
+      <div className="market-intro-coin" aria-hidden="true">
+        <div className="intro-coin-face"><span>1</span><strong>PESETA</strong><small>LA PELA</small></div>
+        <span className="intro-coin-caption">cosas con historia</span>
       </div>
       <div className="intro-note">
         <strong>Tu tiempo también vale.</strong>


### PR DESCRIPTION
## Resumen
- rediseña el logo como un sello-moneda SVG con `LP` y guiños a la peseta
- introduce el sistema visual papel marfil, tinta verde y cobre envejecido
- actualiza hero, navegación, filtros, tarjetas, estados, spinner y pie sin cambiar flujos

## Trazabilidad
- Spec: `specs/LP-FEAT-015-identidad-visual-peseta.md`
- Issue: Closes #43
- Rama: `codex/lp-feat-015-identidad-peseta`

## Evidencia
- `npm run specs:check` ✅
- `npm run build` ✅ (26 páginas, tipos y lint)
- pruebas dirigidas `Header` + `ProductCard` ✅ (3 tests)
- revisión visual responsive en preview local ✅; sin overflow horizontal
- suite frontend completa: mantiene fallos legacy en `search` y `tests-examples/demo-todo-app.spec.ts`, documentados en la spec

## Contexto
`PROJECT_CONTEXT.md` se actualizó para registrar la nueva identidad visual y que la moneda operativa sigue siendo el euro.
