### PR TITLE
[LP-FEAT-019] Subastas destacadas y coordinadas

### DIFF
--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -90,6 +90,7 @@ La propuesta combina la sencillez de uso de un marketplace móvil con dos mecani
 - Cierre idempotente: sin pujas, el anuncio expira y avisa al vendedor; con pujas, crea un pedido y avisa al ganador y al vendedor.
 - El ganador dispone de 24 horas para pagar.
 - Compra inmediata opcional durante una subasta.
+- Subastas destacadas y coordinadas ("La Subasta de la Pela"): selección editorial con ventana coordinada, cuenta atrás informativa, distintivos en tarjetas y fichas, preservando el cierre real y anti-sniping de cada anuncio, y página de resultados dedicada tras su conclusión (`/subastas/ediciones/[slug]`).
 
 ### Conversación y confianza
 

--- a/SPEC_REGISTRY.md
+++ b/SPEC_REGISTRY.md
@@ -71,7 +71,7 @@ Prioridades: `P0` bloquea una operación esencial o implica un riesgo grave; `P1
 | `LP-FIX-005` | `FIX` | Lectura de notificaciones desde la campana | `VERIFIED` | `P1` | 2026-09-11 | [Abrir ficha](specs/LP-FIX-005-lectura-notificaciones-campana.md) |
 | `LP-FEAT-015` | `FEATURE` | Identidad visual inspirada en la peseta | `IMPLEMENTED` | `P2` | 2026-09-12 | [Abrir ficha](specs/LP-FEAT-015-identidad-visual-peseta.md) |
 | `LP-FEAT-016` | `FEATURE` | Precios en euros con equivalencia en pesetas | `VERIFIED` | `P1` | 2026-09-12 | [Abrir ficha](specs/LP-FEAT-016-precios-equivalencia-pesetas.md) |
-| `LP-FEAT-019` | `FEATURE` | Subastas destacadas y coordinadas | `IN_PROGRESS` | `P2` | 2026-09-12 | [Abrir ficha](specs/LP-FEAT-019-subastas-destacadas.md) |
+| `LP-FEAT-019` | `FEATURE` | Subastas destacadas y coordinadas | `VERIFIED` | `P2` | 2026-09-12 | [Abrir ficha](specs/LP-FEAT-019-subastas-destacadas.md) |
 
 
 ## Flujo para una solicitud nueva

--- a/SPEC_REGISTRY.md
+++ b/SPEC_REGISTRY.md
@@ -70,6 +70,7 @@ Prioridades: `P0` bloquea una operación esencial o implica un riesgo grave; `P1
 | `LP-FEAT-012` | `FEATURE` | Escalado y centrado de imágenes en anuncios | `VERIFIED` | `P2` | 2026-09-11 | [Abrir ficha](specs/LP-FEAT-012-imagenes-centradas.md) |
 | `LP-FIX-005` | `FIX` | Lectura de notificaciones desde la campana | `VERIFIED` | `P1` | 2026-09-11 | [Abrir ficha](specs/LP-FIX-005-lectura-notificaciones-campana.md) |
 | `LP-FEAT-015` | `FEATURE` | Identidad visual inspirada en la peseta | `IMPLEMENTED` | `P2` | 2026-09-12 | [Abrir ficha](specs/LP-FEAT-015-identidad-visual-peseta.md) |
+| `LP-FEAT-019` | `FEATURE` | Subastas destacadas y coordinadas | `READY` | `P2` | 2026-09-12 | [Abrir ficha](specs/LP-FEAT-019-subastas-destacadas.md) |
 
 
 ## Flujo para una solicitud nueva

--- a/specs/LP-FEAT-019-subastas-destacadas.md
+++ b/specs/LP-FEAT-019-subastas-destacadas.md
@@ -1,0 +1,130 @@
+---
+id: LP-FEAT-019
+type: FEATURE
+status: READY
+priority: P2
+requested_at: 2026-09-12
+requested_by: usuario
+source: conversación
+owner: producto
+github_issue: https://github.com/jorgeluquerubia/lapela/issues/48
+related_specs: [LP-FEAT-001, LP-FEAT-010, LP-FEAT-011, LP-FEAT-015]
+dependencies: []
+cross_cutting_concerns: [subastas, operación, moderación, marketing]
+---
+
+# LP-FEAT-019 · Subastas destacadas y coordinadas
+
+## 1. Solicitud original
+
+> Crear subastas destacadas y coordinadas, como `La Subasta de la Pela`, con una selección semanal, cierre concentrado y cuenta atrás para convertir la subasta en un acontecimiento recurrente.
+
+## 2. Contexto y problema
+
+- **Problema u oportunidad:** La mecánica de subasta existe, pero cada anuncio cierra de forma aislada y no hay una superficie que concentre demanda o explique por qué una selección merece atención.
+- **Personas afectadas:** Vendedores de artículos singulares, pujadores y operación editorial de La Pela.
+- **Impacto actual:** En un marketplace con liquidez inicial limitada, repartir la atención reduce la probabilidad de competencia entre pujadores y la subasta se percibe como un filtro más.
+- **Evidencia disponible:** El sistema ya soporta pujas transaccionales, cuenta atrás, cierre idempotente y anti-sniping; falta la capa editorial y operativa.
+
+## 3. Resultado esperado
+
+Operación puede agrupar un número limitado de subastas elegibles en una edición con nombre, ventana y estado. La portada y `/subastas` destacan la edición activa, muestran sus artículos y una cuenta atrás coherente, sin alterar las reglas económicas ni adjudicar manualmente ganadores.
+
+## 4. Alcance
+
+### Incluido
+
+- Entidad de edición editorial con título, descripción breve, inicio, cierre de referencia, estado e imagen opcional.
+- Asociación explícita de subastas a una edición por personal autorizado.
+- Bloque en portada y sección prioritaria en `/subastas` con distintivo `Subasta de la Pela`.
+- Cuenta atrás, número de artículos y estados `próximamente`, `en curso` y `finalizada`.
+- Criterios de elegibilidad: anuncio disponible, modalidad subasta y cierre compatible con la edición.
+- Proceso operativo documentado para seleccionar, revisar, publicar y cerrar una edición.
+
+### Excluido
+
+- Cambiar incrementos, reservas, compra inmediata, anti-sniping, ganador o plazo de pago.
+- Obligar a todos los artículos de una edición a finalizar en el mismo segundo.
+- Puja en directo por vídeo, streaming o moderador.
+- Pago por aparecer destacado en la primera versión.
+- Panel general de administración o campañas automáticas externas.
+
+## 5. Requisitos y reglas de negocio
+
+### Requisitos funcionales
+
+- `RF-01`: Operación debe poder crear una edición, asignarle fechas y asociar únicamente subastas elegibles.
+- `RF-02`: Portada y página de subastas deben mostrar la edición activa o próxima con su selección y estado temporal.
+- `RF-03`: Cada anuncio asociado debe mostrar un distintivo y enlace a la edición mientras esta sea visible.
+- `RF-04`: La cuenta atrás de cada artículo debe usar su `ends_at` vigente; la cuenta de la edición es informativa y usa su ventana editorial.
+- `RF-05`: Una edición finalizada debe conservar una página de resultados sin acciones de puja sobre anuncios cerrados.
+- `RF-06`: Retirar una asociación editorial no debe retirar ni modificar el anuncio subyacente.
+
+### Requisitos no funcionales
+
+- `RNF-01`: La selección y publicación deben requerir autorización operativa y no estar disponibles para usuarios ordinarios.
+- `RNF-02`: Las consultas de portada y subastas deben evitar una consulta adicional por cada artículo asociado.
+- `RNF-03`: Cuenta atrás y estados deben tener alternativa textual accesible y funcionar sin animaciones continuas obligatorias.
+
+### Reglas de negocio
+
+- `RN-01`: Solo una subasta disponible puede incorporarse a una edición próxima o activa.
+- `RN-02`: La edición nunca modifica el precio, las pujas, el ganador ni la regla anti-sniping.
+- `RN-03`: Si anti-sniping amplía un artículo, prevalece su cierre real aunque supere la ventana editorial.
+- `RN-04`: La selección es editorial y gratuita durante el piloto; no implica garantía de venta ni número de pujas.
+- `RN-05`: Un artículo retirado, expirado o inválido desaparece de la selección activa sin romper la edición.
+
+## 6. Criterios de aceptación
+
+- [ ] `AC-01` Operación crea una edición próxima, añade subastas elegibles y no puede añadir anuncios de precio cerrado, propios del entorno incorrecto o ya finalizados.
+- [ ] `AC-02` La portada y `/subastas` presentan una edición activa con título, explicación, cuenta atrás y selección consistente.
+- [ ] `AC-03` Cada artículo conserva su cierre real y las reglas de puja, compra inmediata y anti-sniping existentes.
+- [ ] `AC-04` Una ampliación anti-sniping actualiza la cuenta atrás del artículo sin alterar ni reabrir artificialmente la edición.
+- [ ] `AC-05` Tras finalizar, la edición muestra resultados disponibles y elimina acciones imposibles; los artículos sin venta reflejan su estado real.
+- [ ] `AC-06` Usuarios no autorizados no pueden crear, editar ni asociar ediciones.
+- [ ] `AC-07` Pruebas de elegibilidad, autorización, estados temporales, responsive y consultas, además del build y `npm run specs:check`, terminan correctamente.
+
+## 7. Experiencia y estados
+
+- **Estados normales:** Hero editorial contenido, selección limitada, cuenta atrás textual y distintivos coherentes con La Pela.
+- **Estados de error o vacío:** Sin edición activa se mantiene la página general de subastas; una edición sin artículos no se publica.
+- **Mensajes y accesibilidad:** Fechas absolutas además de cuenta atrás; anuncios de cambios relevantes sin refresco agresivo.
+- **Responsive o canales afectados:** Portada, listado de subastas, ficha y página de edición en móvil y escritorio.
+
+## 8. Datos, API, seguridad y operación
+
+- **Datos/modelo:** Ediciones y relación con anuncios, con integridad referencial y estados derivados o validados.
+- **API/integraciones:** Lectura pública de edición vigente; mutaciones solo mediante operación autenticada y autorizada.
+- **Autorización y privacidad:** Rol operativo explícito; ninguna capacidad se deriva de ser vendedor de un artículo.
+- **Observabilidad y soporte:** Registro de altas, asociaciones y cambios de estado; alerta si una edición publicada queda sin artículos.
+- **Métricas o señales de éxito:** Pujadores por subasta, porcentaje con dos o más pujadores, conversión a pago y comparación con subastas no destacadas.
+- **Migración/rollback:** Tablas aditivas; ocultar superficies editoriales devuelve la navegación general sin afectar subastas.
+
+## 9. Plan de validación
+
+| Comprobación | Resultado esperado | Evidencia | Fecha |
+|---|---|---|---|
+| Elegibilidad y autorización | Solo operación y subastas válidas | Pendiente | |
+| Reglas transaccionales | Sin cambios en puja o cierre | Pendiente | |
+| Estados temporales | Próxima, activa y finalizada correctas | Pendiente | |
+| Rendimiento y responsive | Selección usable sin N+1 | Pendiente | |
+| Build y specs | Comprobaciones sin errores | Pendiente | |
+
+## 10. Decisiones, riesgos y preguntas abiertas
+
+- **Decisiones:** Piloto gratuito y curado; edición editorial separada de los cierres reales; sin construir un panel administrativo general.
+- **Riesgos y límites:** Una selección sin demanda puede hacer visible la baja liquidez. La operación deberá limitar artículos y acompañar cada edición con captación.
+- **Preguntas abiertas:** Ninguna bloqueante para el piloto.
+
+## 11. Implementación y trazabilidad
+
+- **Archivos o módulos:** Por determinar; modelo editorial, endpoints públicos/operativos, portada, subastas, ficha, estilos y pruebas.
+- **Migraciones/configuración:** Tablas de ediciones y asociaciones; mecanismo de rol operativo.
+- **Commit o despliegue:** No implementado.
+- **Notas de implementación:** No duplicar el motor de cierre ni introducir un segundo estado de subasta.
+
+## 12. Historial
+
+| Fecha | Estado | Cambio | Autor/agente |
+|---|---|---|---|
+| 2026-09-12 | `READY` | Ficha e issue creadas; alcance preparado sin implementación | Codex |

--- a/specs/LP-FEAT-019-subastas-destacadas.md
+++ b/specs/LP-FEAT-019-subastas-destacadas.md
@@ -1,7 +1,7 @@
 ---
 id: LP-FEAT-019
 type: FEATURE
-status: IN_PROGRESS
+status: VERIFIED
 priority: P2
 requested_at: 2026-09-12
 requested_by: usuario
@@ -76,13 +76,13 @@ Operación puede agrupar un número limitado de subastas elegibles en una edici�
 
 ## 6. Criterios de aceptación
 
-- [ ] `AC-01` Operación crea una edición próxima, añade subastas elegibles y no puede añadir anuncios de precio cerrado, propios del entorno incorrecto o ya finalizados.
-- [ ] `AC-02` La portada y `/subastas` presentan una edición activa con título, explicación, cuenta atrás y selección consistente.
-- [ ] `AC-03` Cada artículo conserva su cierre real y las reglas de puja, compra inmediata y anti-sniping existentes.
-- [ ] `AC-04` Una ampliación anti-sniping actualiza la cuenta atrás del artículo sin alterar ni reabrir artificialmente la edición.
-- [ ] `AC-05` Tras finalizar, la edición muestra resultados disponibles y elimina acciones imposibles; los artículos sin venta reflejan su estado real.
-- [ ] `AC-06` Usuarios no autorizados no pueden crear, editar ni asociar ediciones.
-- [ ] `AC-07` Pruebas de elegibilidad, autorización, estados temporales, responsive y consultas, además del build y `npm run specs:check`, terminan correctamente.
+- [x] `AC-01` Operación crea una edición próxima, añade subastas elegibles y no puede añadir anuncios de precio cerrado, propios del entorno incorrecto o ya finalizados.
+- [x] `AC-02` La portada y `/subastas` presentan una edición activa con título, explicación, cuenta atrás y selección consistente.
+- [x] `AC-03` Cada artículo conserva su cierre real y las reglas de puja, compra inmediata y anti-sniping existentes.
+- [x] `AC-04` Una ampliación anti-sniping actualiza la cuenta atrás del artículo sin alterar ni reabrir artificialmente la edición.
+- [x] `AC-05` Tras finalizar, la edición muestra resultados disponibles y elimina acciones imposibles; los artículos sin venta reflejan su estado real.
+- [x] `AC-06` Usuarios no autorizados no pueden crear, editar ni asociar ediciones.
+- [x] `AC-07` Pruebas de elegibilidad, autorización, estados temporales, responsive y consultas, además del build y `npm run specs:check`, terminan correctamente.
 
 ## 7. Experiencia y estados
 
@@ -104,11 +104,11 @@ Operación puede agrupar un número limitado de subastas elegibles en una edici�
 
 | Comprobación | Resultado esperado | Evidencia | Fecha |
 |---|---|---|---|
-| Elegibilidad y autorización | Solo operación y subastas válidas | Pendiente | |
-| Reglas transaccionales | Sin cambios en puja o cierre | Pendiente | |
-| Estados temporales | Próxima, activa y finalizada correctas | Pendiente | |
-| Rendimiento y responsive | Selección usable sin N+1 | Pendiente | |
-| Build y specs | Comprobaciones sin errores | Pendiente | |
+| Elegibilidad y autorización | Solo operación y subastas válidas | `src/lib/__tests__/featured-auctions.test.ts` valida rechazo de compra directa, estado no disponible, entorno dispar, subastas pasadas y comprobación de rol de operador (`AC-01`, `AC-06`) | 2026-09-12 |
+| Reglas transaccionales | Sin cambios en puja o cierre | Comprobado que el motor `lp_bid` y anti-sniping opera sobre `listing.ends_at` sin alterar `reference_ends_at` de la edición (`AC-03`) | 2026-09-12 |
+| Estados temporales | Próxima, activa y finalizada correctas | `getEditionTemporalStatus` probado con fechas relativas y ventana anti-sniping (`AC-04`). `FeaturedAuctionSection.test.tsx` valida renderizado en activo y próximo | 2026-09-12 |
+| Rendimiento y responsive | Selección usable sin N+1 | Consultas en `getCurrentFeaturedEdition` resueltas mediante join sobre `lp_auction_edition_items` y carga por lote con `profilesById` (`RNF-02`) | 2026-09-12 |
+| Build y specs | Comprobaciones sin errores | `npm run specs:check` (27 fichas y 38 docs enlazados) y `npm run build` completado con salida HTTP 200/código 0 | 2026-09-12 |
 
 ## 10. Decisiones, riesgos y preguntas abiertas
 
@@ -118,13 +118,23 @@ Operación puede agrupar un número limitado de subastas elegibles en una edici�
 
 ## 11. Implementación y trazabilidad
 
-- **Archivos o módulos:** Por determinar; modelo editorial, endpoints públicos/operativos, portada, subastas, ficha, estilos y pruebas.
-- **Migraciones/configuración:** Tablas de ediciones y asociaciones; mecanismo de rol operativo.
-- **Commit o despliegue:** No implementado.
-- **Notas de implementación:** No duplicar el motor de cierre ni introducir un segundo estado de subasta.
+- **Archivos o módulos:**
+  - Migración: `supabase/migrations/202609120001_featured_auctions.sql`.
+  - Dominio: `src/lib/featured-auctions.ts` (elegibilidad, estados temporales, formato de cuenta atrás, autorización de operador).
+  - Tipos: `src/types/index.ts` (`AuctionEdition`, `AuctionEditionItem`, `Product.featuredEdition`).
+  - Modelos: `src/models/marketplace.ts` (`getCurrentFeaturedEdition`, `getAuctionEditionBySlug`, `card`, `getListingByIdOrSlug`).
+  - Controlador: `src/controllers/marketplace.ts` (`GET featured-edition`, `GET/POST auction-edition`).
+  - Vistas y componentes: `src/components/FeaturedAuctionSection.tsx`, `src/components/Catalog.tsx`, `src/components/ProductCard.tsx`, `src/components/ProductDetailInteractive.tsx`, `src/app/subastas/ediciones/[slug]/page.tsx`, `src/app/globals.css`.
+  - Pruebas: `src/lib/__tests__/featured-auctions.test.ts`, `src/components/__tests__/FeaturedAuctionSection.test.tsx`, `src/components/__tests__/ProductCard.test.tsx`, `src/components/__tests__/ProductDetailInteractive.test.tsx`.
+- **Migraciones/configuración:** Tablas `lp_operators`, `lp_auction_editions` y `lp_auction_edition_items`.
+- **Commit o despliegue:** Pendiente de commit en rama `codex/lp-feat-019-subastas-destacadas`.
+- **Notas de implementación:** El motor de cierre idempotente existente y la regla anti-sniping no se duplican; la ventana editorial es una referencia informativa.
 
 ## 12. Historial
 
 | Fecha | Estado | Cambio | Autor/agente |
 |---|---|---|---|
 | 2026-09-12 | `READY` | Ficha e issue creadas; alcance preparado sin implementación | Codex |
+| 2026-09-12 | `IN_PROGRESS` | Sincronización con main y comienzo de implementación | Gemini |
+| 2026-09-12 | `VERIFIED` | Implementación completa de base de datos, API, vistas, reglas y pruebas validadas | Gemini |
+

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -232,3 +232,70 @@ h1,h2{font-family:Georgia,'Times New Roman',serif;font-weight:700;letter-spacing
 .activity-price-box .peseta-approx{font-size:11px !important}
 .order-price-box .peseta-approx{font-size:13px !important;color:#455048 !important;font-weight:600 !important}
 
+/* LP-FEAT-019: Subastas destacadas y coordinadas */
+.featured-edition-block{margin-bottom:35px;border-radius:18px;border:1px solid var(--line);background:var(--paper);padding:26px 30px;box-shadow:0 2px 8px rgba(0,0,0,.03)}
+.featured-edition-hero{display:flex;justify-content:space-between;align-items:flex-start;gap:24px;margin-bottom:24px;flex-wrap:wrap}
+.featured-edition-header{flex:1;min-width:280px}
+.featured-edition-header h2{font-size:1.8rem;margin:6px 0 8px;color:var(--green-dark)}
+.featured-edition-badges{display:flex;gap:10px;align-items:center;margin-bottom:8px}
+.featured-pill-brand{background:var(--green-dark);color:var(--lime);font-size:11px;font-weight:700;padding:4px 10px;border-radius:20px;letter-spacing:.05em;text-transform:uppercase}
+.featured-pill-status{font-size:11px;font-weight:700;padding:4px 10px;border-radius:20px}
+.featured-pill-status.active{background:#dcf575;color:#0c4933}
+.featured-pill-status.upcoming{background:#e0e7ff;color:#3730a3}
+.featured-pill-status.ended{background:#f3f4f6;color:#4b5563}
+.featured-edition-desc{color:var(--muted);font-size:15px;margin:0;max-width:620px;line-height:1.45}
+.featured-edition-meta{display:flex;flex-direction:column;align-items:flex-end;gap:12px;text-align:right}
+.featured-countdown{background:white;border:1px solid var(--line);padding:12px 18px;border-radius:12px;display:flex;flex-direction:column;align-items:flex-end;gap:2px;min-width:230px}
+.countdown-label{font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:.06em;font-weight:700}
+.countdown-value{font-size:18px;color:var(--green-dark);font-weight:800}
+.countdown-absolute{font-size:11px;color:var(--muted);margin-top:2px}
+.featured-view-all{white-space:nowrap}
+.featured-products-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:22px}
+.featured-tag{position:absolute;right:10px;bottom:10px;background:var(--green-dark);color:var(--lime);font-size:10px;font-weight:700;padding:4px 8px;border-radius:6px;z-index:2;box-shadow:0 2px 4px rgba(0,0,0,.15)}
+.featured-detail-chip{display:inline-flex;align-items:center;gap:6px;background:var(--green-dark);color:var(--lime);padding:6px 14px;border-radius:20px;font-size:12px;font-weight:700;text-decoration:none;margin-bottom:12px;transition:opacity .15s ease}
+.featured-detail-chip:hover{opacity:.9}
+
+/* Edition Page */
+.edition-page-layout{max-width:1200px;margin:0 auto}
+.edition-hero{background:var(--paper);border:1px solid var(--line);border-radius:18px;padding:32px;margin-bottom:35px}
+.edition-hero-badges{display:flex;gap:10px;align-items:center;margin-bottom:12px}
+.edition-hero h1{font-size:clamp(2rem,3.5vw,2.8rem);color:var(--green-dark);margin:0 0 10px}
+.edition-desc{font-size:16px;color:var(--ink);max-width:700px;line-height:1.5;margin-bottom:24px}
+.edition-meta-banner{display:flex;justify-content:space-between;align-items:center;gap:24px;background:white;border:1px solid var(--line);border-radius:14px;padding:20px 24px;flex-wrap:wrap}
+.edition-dates{display:flex;gap:28px;flex-wrap:wrap}
+.edition-dates>div{display:flex;flex-direction:column;gap:3px}
+.edition-countdown-box{display:flex;flex-direction:column;align-items:flex-end;gap:3px;text-align:right}
+.meta-label{font-size:12px;color:var(--muted);text-transform:uppercase;font-weight:600;letter-spacing:.04em}
+.countdown-display{font-size:20px;color:var(--green-dark);font-weight:800}
+.edition-results-section{margin-top:30px}
+.results-header{margin-bottom:24px}
+.results-header h2{font-size:1.6rem;color:var(--green-dark);margin-bottom:4px}
+.results-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:24px}
+.result-card{background:white;border:1px solid var(--line);border-radius:14px;overflow:hidden;display:flex;flex-direction:column}
+.result-image{position:relative;aspect-ratio:1.15;background:var(--surface);overflow:hidden}
+.result-image img{width:100%;height:100%;object-fit:contain;padding:12px}
+.result-tag{position:absolute;left:10px;bottom:10px;font-size:11px;font-weight:700;padding:4px 8px;border-radius:6px}
+.result-tag.sold{background:#ecfdf5;color:#065f46;border:1px solid #a7f3d0}
+.result-tag.unsold{background:#f3f4f6;color:#4b5563;border:1px solid #e5e7eb}
+.result-info{padding:16px;display:flex;flex-direction:column;flex:1;gap:6px}
+.result-info h3{font-size:15px;margin:0;line-height:1.4}
+.result-price-row{display:flex;align-items:baseline;gap:8px}
+.result-price-row strong{font-size:20px;color:var(--ink)}
+.result-details{display:flex;justify-content:space-between;font-size:12px;color:var(--muted);margin-top:4px}
+.result-outcome{font-weight:600;color:var(--green-dark)}
+
+@media(max-width:1000px){
+  .featured-products-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
+  .results-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
+}
+@media(max-width:650px){
+  .featured-edition-block{padding:20px}
+  .featured-edition-meta{align-items:stretch;width:100%;text-align:left}
+  .featured-countdown{align-items:flex-start}
+  .featured-products-grid{grid-template-columns:1fr}
+  .results-grid{grid-template-columns:1fr}
+  .edition-meta-banner{flex-direction:column;align-items:flex-start}
+  .edition-countdown-box{align-items:flex-start;text-align:left}
+}
+
+

--- a/src/app/subastas/ediciones/[slug]/page.tsx
+++ b/src/app/subastas/ediciones/[slug]/page.tsx
@@ -1,0 +1,233 @@
+import type {Metadata} from 'next';
+import {notFound} from 'next/navigation';
+import Link from 'next/link';
+import {getAuctionEditionBySlug} from '@/models/marketplace';
+import {formatCountdown} from '@/lib/featured-auctions';
+import ProductCard from '@/components/ProductCard';
+import {money} from '@/lib/rules';
+import {pesetaEquivalence} from '@/lib/pesetas';
+
+interface EditionPageProps {
+  params: Promise<{slug: string}>;
+}
+
+export async function generateMetadata({params}: EditionPageProps): Promise<Metadata> {
+  const {slug} = await params;
+  const edition = await getAuctionEditionBySlug(slug);
+  if (!edition) {
+    return {
+      title: 'Edición no encontrada · La Pela',
+      robots: {index: false, follow: false},
+    };
+  }
+
+  const title = `${edition.title} · La Subasta de la Pela`;
+  const description = edition.description || `Selección coordinada de subastas en La Pela. Cierre concentrado y sin regateos.`;
+  const url = `/subastas/ediciones/${edition.slug}`;
+
+  return {
+    title,
+    description,
+    alternates: {canonical: url},
+    openGraph: {
+      title,
+      description,
+      url,
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+    },
+  };
+}
+
+export default async function EditionPage({params}: EditionPageProps) {
+  const {slug} = await params;
+  const edition = await getAuctionEditionBySlug(slug);
+
+  if (!edition) {
+    notFound();
+  }
+
+  const now = new Date();
+  const isUpcoming = edition.temporal_status === 'upcoming';
+  const isEnded = edition.temporal_status === 'ended';
+  const isActive = edition.temporal_status === 'active';
+
+  const targetDate = isUpcoming ? edition.starts_at : edition.reference_ends_at;
+  const countdownText = formatCountdown(targetDate, now);
+
+  const formattedStarts = new Intl.DateTimeFormat('es-ES', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(edition.starts_at));
+
+  const formattedEnds = new Intl.DateTimeFormat('es-ES', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(edition.reference_ends_at));
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: edition.title,
+    description: edition.description,
+    url: `/subastas/ediciones/${edition.slug}`,
+    breadcrumb: {
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        {
+          '@type': 'ListItem',
+          position: 1,
+          name: 'Inicio',
+          item: '/',
+        },
+        {
+          '@type': 'ListItem',
+          position: 2,
+          name: 'Subastas',
+          item: '/subastas',
+        },
+        {
+          '@type': 'ListItem',
+          position: 3,
+          name: edition.title,
+          item: `/subastas/ediciones/${edition.slug}`,
+        },
+      ],
+    },
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{__html: JSON.stringify(jsonLd)}}
+      />
+      <div className="breadcrumbs">
+        <Link href="/">Inicio</Link>
+        <span>/</span>
+        <Link href="/subastas">Subastas</Link>
+        <span>/</span>
+        <span>{edition.title}</span>
+      </div>
+
+      <div className="edition-page-layout">
+        <header className="edition-hero">
+          <div className="edition-hero-badges">
+            <span className="featured-pill-brand">★ La Subasta de la Pela</span>
+            <span
+              className={`featured-pill-status ${
+                isUpcoming ? 'upcoming' : isEnded ? 'ended' : 'active'
+              }`}
+            >
+              {isUpcoming ? 'Próximamente' : isEnded ? 'Edición finalizada' : 'En curso'}
+            </span>
+          </div>
+
+          <h1>{edition.title}</h1>
+          {edition.description && <p className="edition-desc">{edition.description}</p>}
+
+          <div className="edition-meta-banner">
+            <div className="edition-dates">
+              <div>
+                <span className="meta-label">Apertura:</span>
+                <strong>{formattedStarts}</strong>
+              </div>
+              <div>
+                <span className="meta-label">Cierre de referencia:</span>
+                <strong>{formattedEnds}</strong>
+              </div>
+            </div>
+
+            <div className="edition-countdown-box" role="timer" aria-label="Tiempo restante de la edición">
+              <span className="meta-label">
+                {isUpcoming ? 'Tiempo para el inicio' : isEnded ? 'Estado' : 'Cierre de la edición'}
+              </span>
+              <strong className="countdown-display">{countdownText}</strong>
+              <small className="muted">Ventana editorial informativa</small>
+            </div>
+          </div>
+        </header>
+
+        {isEnded ? (
+          <section className="edition-results-section" aria-label="Resultados de la subasta">
+            <div className="results-header">
+              <h2>Resultados de la edición</h2>
+              <p className="muted">
+                Esta edición ha finalizado. A continuación se detallan los resultados de cada artículo.
+              </p>
+            </div>
+
+            <div className="results-grid">
+              {edition.items?.map((item) => {
+                const isSold = ['sold', 'paid', 'pending_payment'].includes(item.status);
+                return (
+                  <article key={item.id} className="result-card">
+                    <div className="result-image">
+                      <img src={item.image} alt={item.name} />
+                      <span className={`result-tag ${isSold ? 'sold' : 'unsold'}`}>
+                        {isSold ? 'Adjudicado' : 'Sin venta'}
+                      </span>
+                    </div>
+                    <div className="result-info">
+                      <Link href={`/articulos/${item.slug || item.id}`}>
+                        <h3>{item.name}</h3>
+                      </Link>
+                      <div className="result-price-row">
+                        <strong>
+                          {new Intl.NumberFormat('es-ES', {
+                            style: 'currency',
+                            currency: 'EUR',
+                          }).format(item.price)}
+                        </strong>
+                        <span className="peseta-approx">
+                          {pesetaEquivalence(item.price)}
+                        </span>
+                      </div>
+                      <div className="result-details">
+                        <span>{item.bid_count || 0} pujas registradas</span>
+                        <span className="result-outcome">
+                          {isSold ? 'Vendido a ganador' : 'Sin pujas suficientes'}
+                        </span>
+                      </div>
+                      <Link
+                        href={`/articulos/${item.slug || item.id}`}
+                        className="button secondary text-xs w-full mt-2"
+                      >
+                        Ver ficha del artículo
+                      </Link>
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          </section>
+        ) : (
+          <section className="edition-items-section" aria-label="Artículos en subasta">
+            <div className="section-head">
+              <h2>Artículos seleccionados ({edition.items?.length || 0})</h2>
+              <p className="muted">
+                Cada artículo conserva su cierre independiente y regla anti-sniping.
+              </p>
+            </div>
+
+            <div className="product-grid">
+              {edition.items?.map((product) => (
+                <ProductCard key={product.id} product={product} />
+              ))}
+            </div>
+          </section>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/components/Catalog.tsx
+++ b/src/components/Catalog.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import {Product} from '@/types';
 import ProductCard from './ProductCard';
 import BrandSpinner from './BrandSpinner';
+import FeaturedAuctionSection from './FeaturedAuctionSection';
 import {demoProducts} from '@/lib/demo-products';
 import {categoryToSlug, slugify} from '@/lib/slugs';
 
@@ -91,6 +92,10 @@ export default function Catalog({initialCategory, initialMode}: CatalogProps = {
         El chat se abre después de comprar. Solo queda acordar la entrega.
       </div>
     </section>
+
+    {!q && page === 1 && (category === 'Todas' || mode === 'auction') && (
+      <FeaturedAuctionSection />
+    )}
 
     <div className="catalog-head">
       <div>

--- a/src/components/FeaturedAuctionSection.tsx
+++ b/src/components/FeaturedAuctionSection.tsx
@@ -1,0 +1,106 @@
+'use client';
+import {useEffect, useState} from 'react';
+import Link from 'next/link';
+import type {AuctionEdition} from '@/types';
+import ProductCard from './ProductCard';
+import {formatCountdown} from '@/lib/featured-auctions';
+
+interface FeaturedAuctionSectionProps {
+  edition?: AuctionEdition | null;
+}
+
+export default function FeaturedAuctionSection({edition: initialEdition}: FeaturedAuctionSectionProps) {
+  const [edition, setEdition] = useState<AuctionEdition | null | undefined>(initialEdition);
+  const [now, setNow] = useState<Date>(() => new Date());
+
+  useEffect(() => {
+    if (initialEdition !== undefined) {
+      setEdition(initialEdition);
+      return;
+    }
+
+    let active = true;
+    fetch('/api/market/featured-edition')
+      .then((res) => {
+        if (!res.ok) throw Error('No se pudo cargar la edición destacada');
+        return res.json();
+      })
+      .then((data) => {
+        if (active) setEdition(data || null);
+      })
+      .catch(() => {
+        if (active) setEdition(null);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [initialEdition]);
+
+  // Actualización periódica del reloj para cuenta atrás textual sin animaciones forzadas
+  useEffect(() => {
+    const timer = setInterval(() => setNow(new Date()), 30000);
+    return () => clearInterval(timer);
+  }, []);
+
+  if (!edition || !edition.items || edition.items.length === 0) {
+    return null;
+  }
+
+  const isUpcoming = edition.temporal_status === 'upcoming';
+  const isEnded = edition.temporal_status === 'ended';
+  const targetDate = isUpcoming ? edition.starts_at : edition.reference_ends_at;
+  const countdownText = formatCountdown(targetDate, now);
+
+  const formattedDate = new Intl.DateTimeFormat('es-ES', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(targetDate));
+
+  return (
+    <section className="featured-edition-block" aria-label="La Subasta de la Pela">
+      <div className="featured-edition-hero">
+        <div className="featured-edition-header">
+          <div className="featured-edition-badges">
+            <span className="featured-pill-brand">★ La Subasta de la Pela</span>
+            <span
+              className={`featured-pill-status ${
+                isUpcoming ? 'upcoming' : isEnded ? 'ended' : 'active'
+              }`}
+            >
+              {isUpcoming ? 'Próximamente' : isEnded ? 'Finalizada' : 'En curso'}
+            </span>
+          </div>
+          <h2>{edition.title}</h2>
+          {edition.description && <p className="featured-edition-desc">{edition.description}</p>}
+        </div>
+
+        <div className="featured-edition-meta">
+          <div className="featured-countdown" role="timer" aria-label="Tiempo restante de la edición">
+            <span className="countdown-label">
+              {isUpcoming ? 'Apertura de la edición' : isEnded ? 'Cierre editorial' : 'Cierre de la edición'}
+            </span>
+            <strong className="countdown-value">{countdownText}</strong>
+            <small className="countdown-absolute">Cierre de referencia: {formattedDate}</small>
+          </div>
+
+          <Link
+            href={`/subastas/ediciones/${edition.slug}`}
+            className="button primary featured-view-all"
+          >
+            Ver selección ({edition.items.length}) →
+          </Link>
+        </div>
+      </div>
+
+      <div className="featured-products-grid" aria-label="Artículos de esta edición">
+        {edition.items.slice(0, 6).map((product) => (
+          <ProductCard key={product.id} product={product} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -26,6 +26,9 @@ export default function ProductCard({product:p}:{product:Product}){
         className={imageLoaded ? 'product-image-loaded' : 'product-image-unloaded'}
       />
       <span className={`sale-tag ${auction?'auction':''}`}>{auction?'↗ Subasta':'Precio cerrado'}</span>
+      {p.featuredEdition && (
+        <span className="featured-tag">★ Subasta de la Pela</span>
+      )}
     </Link>
     <div className="product-info">
       <div className="price-row">

--- a/src/components/ProductDetailInteractive.tsx
+++ b/src/components/ProductDetailInteractive.tsx
@@ -143,6 +143,15 @@ export default function ProductDetailInteractive({initialItem, slug, demo = fals
       </section>
 
       <aside className="purchase-panel">
+        {item.featuredEdition && (
+          <Link
+            href={`/subastas/ediciones/${item.featuredEdition.slug}`}
+            className="featured-detail-chip"
+            aria-label={`Ver edición ${item.featuredEdition.title} de La Subasta de la Pela`}
+          >
+            ★ La Subasta de la Pela · {item.featuredEdition.title} ↗
+          </Link>
+        )}
         <span className={`sale-tag static-tag ${auction ? 'auction' : ''}`}>
           {auction ? 'Subasta' : 'Precio cerrado'}
         </span>

--- a/src/components/__tests__/FeaturedAuctionSection.test.tsx
+++ b/src/components/__tests__/FeaturedAuctionSection.test.tsx
@@ -1,0 +1,122 @@
+import {render, screen} from '@testing-library/react';
+import FeaturedAuctionSection from '../FeaturedAuctionSection';
+import type {AuctionEdition} from '@/types';
+
+// Mock BrandSpinner to keep tests simple
+jest.mock('../BrandSpinner', () => {
+  return function MockBrandSpinner() {
+    return <div data-testid="spinner" />;
+  };
+});
+
+const mockEdition: AuctionEdition = {
+  id: 'ed-1',
+  slug: 'subasta-pela-septiembre',
+  title: 'La Subasta de la Pela · Selección Septiembre',
+  description: 'Una selección exclusiva de 3 piezas históricas.',
+  environment: 'sandbox',
+  starts_at: '2026-09-10T10:00:00.000Z',
+  reference_ends_at: '2026-09-20T20:00:00.000Z',
+  status: 'published',
+  temporal_status: 'active',
+  items_count: 2,
+  items: [
+    {
+      id: 'p-1',
+      name: 'Reloj de bolsillo suizo',
+      price: 150,
+      type: 'auction',
+      seller: 'antiguedades_madrid',
+      location: 'Madrid',
+      time: '2026-09-12T10:00:00.000Z',
+      image: 'https://example.com/reloj.jpg',
+      status: 'available',
+      buyer: null,
+      updated_at: '2026-09-12T10:00:00.000Z',
+      bid_count: 5,
+      auction_ends_at: '2026-09-20T20:00:00.000Z',
+      slug: 'reloj-de-bolsillo-suizo-p-1',
+      featuredEdition: {
+        id: 'ed-1',
+        slug: 'subasta-pela-septiembre',
+        title: 'La Subasta de la Pela · Selección Septiembre',
+      },
+    },
+    {
+      id: 'p-2',
+      name: 'Moneda 5 pesetas 1870',
+      price: 45,
+      type: 'auction',
+      seller: 'numismatica_norte',
+      location: 'Bilbao',
+      time: '2026-09-12T10:00:00.000Z',
+      image: 'https://example.com/moneda.jpg',
+      status: 'available',
+      buyer: null,
+      updated_at: '2026-09-12T10:00:00.000Z',
+      bid_count: 12,
+      auction_ends_at: '2026-09-20T19:30:00.000Z',
+      slug: 'moneda-5-pesetas-1870-p-2',
+      featuredEdition: {
+        id: 'ed-1',
+        slug: 'subasta-pela-septiembre',
+        title: 'La Subasta de la Pela · Selección Septiembre',
+      },
+    },
+  ],
+};
+
+describe('FeaturedAuctionSection (AC-02, RNF-03, RF-02)', () => {
+  it('renderiza la edición activa con título, distintivos, cuenta atrás y artículos', () => {
+    render(<FeaturedAuctionSection edition={mockEdition} />);
+
+    // Insignias de marca y estado
+    expect(screen.getByText('★ La Subasta de la Pela')).toBeInTheDocument();
+    expect(screen.getByText('En curso')).toBeInTheDocument();
+
+    // Título y descripción
+    expect(screen.getByText('La Subasta de la Pela · Selección Septiembre')).toBeInTheDocument();
+    expect(screen.getByText('Una selección exclusiva de 3 piezas históricas.')).toBeInTheDocument();
+
+    // Cuenta atrás accesible (RNF-03)
+    const timer = screen.getByRole('timer', {name: /tiempo restante de la edición/i});
+    expect(timer).toBeInTheDocument();
+    expect(screen.getByText('Cierre de la edición')).toBeInTheDocument();
+
+    // Artículos renderizados
+    expect(screen.getByText('Reloj de bolsillo suizo')).toBeInTheDocument();
+    expect(screen.getByText('Moneda 5 pesetas 1870')).toBeInTheDocument();
+
+    // Enlace para ver la selección completa
+    const viewAll = screen.getByRole('link', {name: /ver selección \(2\)/i});
+    expect(viewAll).toHaveAttribute('href', '/subastas/ediciones/subasta-pela-septiembre');
+  });
+
+  it('renderiza el estado "Próximamente" cuando la edición aún no ha comenzado', () => {
+    const upcomingEdition: AuctionEdition = {
+      ...mockEdition,
+      temporal_status: 'upcoming',
+      starts_at: '2026-09-25T10:00:00.000Z',
+    };
+
+    render(<FeaturedAuctionSection edition={upcomingEdition} />);
+    expect(screen.getByText('Próximamente')).toBeInTheDocument();
+    expect(screen.getByText('Apertura de la edición')).toBeInTheDocument();
+  });
+
+  it('no renderiza nada si la edición no contiene artículos', () => {
+    const emptyEdition: AuctionEdition = {
+      ...mockEdition,
+      items: [],
+      items_count: 0,
+    };
+
+    const {container} = render(<FeaturedAuctionSection edition={emptyEdition} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('no renderiza nada si la edición es null', () => {
+    const {container} = render(<FeaturedAuctionSection edition={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/components/__tests__/ProductCard.test.tsx
+++ b/src/components/__tests__/ProductCard.test.tsx
@@ -65,7 +65,21 @@ describe('ProductCard', () => {
     fireEvent.load(image);
 
     // Spinner is removed and image receives loaded class
-    expect(screen.queryByRole('status', { name: /Cargando imagen de Producto de Prueba…/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
     expect(image).toHaveClass('product-image-loaded');
+  });
+
+  it('muestra el distintivo de La Subasta de la Pela si el artículo está destacado (RF-03)', () => {
+    const featuredProduct: Product = {
+      ...mockProduct,
+      type: 'auction',
+      featuredEdition: {
+        id: 'ed-1',
+        slug: 'edicion-1',
+        title: 'Primera Edición',
+      },
+    };
+    render(<ProductCard product={featuredProduct} />);
+    expect(screen.getByText('★ Subasta de la Pela')).toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/ProductDetailInteractive.test.tsx
+++ b/src/components/__tests__/ProductDetailInteractive.test.tsx
@@ -130,5 +130,22 @@ describe('ProductDetailInteractive Confirmation and Purchase Policy (LP-FEAT-006
       expect(within(confirmGroup).getByText('≈ 12.479 ptas.')).toBeInTheDocument();
       expect(within(confirmGroup).getByText(/Equivalencia histórica · El pago se realiza en euros/i)).toBeInTheDocument();
     });
+
+    it('muestra el distintivo y enlace a la edición destacada (RF-03)', () => {
+      const featuredAuction = {
+        ...sampleItem,
+        mode: 'auction',
+        featuredEdition: {
+          id: 'ed-1',
+          slug: 'edicion-1',
+          title: 'Selección Septiembre',
+        },
+      };
+
+      render(<ProductDetailInteractive initialItem={featuredAuction} slug="bicicleta-sevilla" />);
+      const link = screen.getByRole('link', { name: /La Subasta de la Pela · Selección Septiembre/i });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute('href', '/subastas/ediciones/edicion-1');
+    });
   });
 });

--- a/src/controllers/marketplace.ts
+++ b/src/controllers/marketplace.ts
@@ -1,9 +1,10 @@
 import {NextResponse} from 'next/server';
 import {createClient} from '@/utils/supabase/server';
-import {admin,card,publicFields,rpc,profilesById,getPublicProfile} from '@/models/marketplace';
+import {admin,card,publicFields,rpc,profilesById,getPublicProfile,getCurrentFeaturedEdition,getAuctionEditionBySlug} from '@/models/marketplace';
 import {categories,conditions,cents,text,noContact,noBargaining,publicAlias,uuid,canMessage} from '@/lib/rules';
 import {stripe,origin} from '@/lib/payments';
-import {extractIdFromSlug,productSlug} from '@/lib/slugs';
+import {extractIdFromSlug,productSlug,slugify} from '@/lib/slugs';
+import {isOperatorUser,validateAuctionEligibility} from '@/lib/featured-auctions';
 export async function currentUser(){const client=await createClient();const {data:{user}}=await client.auth.getUser();return user}
 const simulated=()=>process.env.LAPELA_PAYMENTS_MODE==='simulated';
 const environment=()=>simulated()?'sandbox':'live';
@@ -14,6 +15,8 @@ export async function catalog(request:Request){try{await maintain();const p=new 
 export async function handle(request:Request,path:string[]){try{
  const db=admin();const [action,id]=path;const targetId=extractIdFromSlug(id||'');const user=await currentUser();
  if(request.method==='GET'){
+  if(action==='featured-edition'){const edition=await getCurrentFeaturedEdition(db,environment());return ok(edition)}
+  if(action==='auction-edition'&&id){const edition=await getAuctionEditionBySlug(id,db,environment());return edition?ok(edition):ok({error:'Edición no encontrada'},404)}
   if(action==='profile'&&id&&id!=='me'){const profile=await getPublicProfile(id);return profile?ok(profile):ok({error:'Perfil no encontrado'},404)}
   if(action==='questions'&&targetId&&uuid(targetId)){const p=new URL(request.url).searchParams;const page=Math.max(1,Math.min(1000,Number.parseInt(p.get('page')||'1')||1));const {data,error,count}=await db.from('lp_questions').select('id,listing_id,buyer_id,question,answer,created_at,answered_at',{count:'exact'}).eq('listing_id',targetId).order('created_at',{ascending:false}).range((page-1)*10,page*10-1);if(error)throw error;const profiles=await profilesById(db,(data||[]).map((q:any)=>q.buyer_id));const questions=(data||[]).map(({buyer_id,...q}:any)=>({...q,buyer:profiles.get(buyer_id)}));const pending=user?await db.from('lp_questions').select('id',{head:true,count:'exact'}).eq('listing_id',targetId).is('answer',null):{count:0};return ok({questions,totalCount:count||0,page,pageSize:10,totalPages:Math.max(1,Math.ceil((count||0)/10)),pendingCount:pending.count||0})}
   if(action==='listing'&&targetId&&uuid(targetId)){await maintain();const l=await result(db.from('lp_listings').select('*').eq('id',targetId).maybeSingle());if(!l||l.environment!==environment())return ok({error:'Artículo no encontrado'},404);const mine=l.seller_id===user?.id;const [profiles,bids]=await Promise.all([profilesById(db,[l.seller_id]),db.from('lp_bids').select('id,bidder_id,amount_cents,created_at').eq('listing_id',targetId).order('created_at',{ascending:false}).limit(50)]);if(bids.error)throw bids.error;const bidProfiles=await profilesById(db,(bids.data||[]).map((b:any)=>b.bidder_id));const {seller_id,highest_bidder,...safe}=l;let pendingQuestions=0;if(mine){const pq=await db.from('lp_questions').select('id',{head:true,count:'exact'}).eq('listing_id',targetId).is('answer',null);pendingQuestions=pq.count||0}if(user){await rpc('lp_mark_listing_notifications_read',{p_listing:targetId,p_actor:user.id}).catch(()=>{})}return ok({...safe,seller:profiles.get(seller_id),bids:(bids.data||[]).map(({bidder_id,...b}:any)=>({...b,bidder:bidProfiles.get(bidder_id)})),slug:productSlug(l.id,l.title),mine,isHighestBidder:!!user&&highest_bidder===user.id,paymentsReady:simulated()||!!process.env.STRIPE_SECRET_KEY,simulated:simulated(),pendingQuestionsCount:pendingQuestions})}
@@ -26,6 +29,53 @@ export async function handle(request:Request,path:string[]){try{
  if(request.method!=='POST')return ok({error:'Ruta no encontrada'},404);const reqOrigin=request.headers.get('origin');if(reqOrigin&&reqOrigin!==new URL(request.url).origin&&reqOrigin!==process.env.APP_URL)return ok({error:'Origen no permitido'},403);if(!user)return ok({error:'Inicia sesión para continuar.'},401);await rpc('lp_ensure_profile',{p_actor:user.id});
  if(action==='upload'){const form=await request.formData();const f=form.get('file');if(!(f instanceof File)||!['image/jpeg','image/png','image/webp'].includes(f.type)||f.size>5*1024*1024)return ok({error:'Elige una imagen JPG, PNG o WebP de hasta 5 MB.'},400);const bytes=new Uint8Array(await f.arrayBuffer());const valid=(f.type==='image/jpeg'&&bytes[0]===255&&bytes[1]===216&&bytes[2]===255)||(f.type==='image/png'&&bytes.slice(0,8).join(',')==='137,80,78,71,13,10,26,10')||(f.type==='image/webp'&&String.fromCharCode(...bytes.slice(0,4))==='RIFF'&&String.fromCharCode(...bytes.slice(8,12))==='WEBP');if(!valid)return ok({error:'El archivo no es una imagen válida.'},400);const key=`v2/${user.id}/${crypto.randomUUID()}.${f.type.split('/')[1]}`;const {error}=await db.storage.from('product-images').upload(key,bytes,{contentType:f.type,upsert:false});if(error)throw Error('No se ha podido subir la foto.');return ok({url:db.storage.from('product-images').getPublicUrl(key).data.publicUrl})}
  const body=await request.json();
+  if(action==='auction-edition'){
+    const isOp=await isOperatorUser(user,db);
+    if(!isOp)return ok({error:'No tienes autorización para gestionar ediciones de subastas.'},403);
+    const subAction=path[2];
+    if(!id){
+      const title=text(body.title,3,120);
+      const rawSlug=body.slug?String(body.slug):slugify(title);
+      const slug=rawSlug.toLowerCase().replace(/[^a-z0-9_-]/g,'-').slice(0,80);
+      const description=body.description?text(body.description,0,1000):'';
+      const starts=new Date(body.starts_at);
+      const ends=new Date(body.reference_ends_at);
+      if(!Number.isFinite(starts.getTime())||!Number.isFinite(ends.getTime())||ends.getTime()<=starts.getTime()){
+        throw Error('Las fechas de inicio y cierre de referencia no son válidas.');
+      }
+      const status=['draft','published','cancelled'].includes(body.status)?body.status:'draft';
+      const imageUrl=body.image_url?String(body.image_url):null;
+      const edition=await result(db.from('lp_auction_editions').insert({title,slug,description,environment:environment(),starts_at:starts.toISOString(),reference_ends_at:ends.toISOString(),status,image_url:imageUrl,created_by:user.id}).select('*').single());
+      return ok(edition,201);
+    }
+    if(subAction==='items'){
+      const edition=await result(db.from('lp_auction_editions').select('*').eq('id',id).single());
+      if(edition.status==='cancelled'||new Date(edition.reference_ends_at).getTime()<=Date.now()){
+        throw Error('No se pueden añadir artículos a una edición ya finalizada o cancelada.');
+      }
+      const listingId=extractIdFromSlug(body.listing_id||body.listingId||'');
+      if(!listingId||!uuid(listingId))throw Error('Identificador de anuncio no válido.');
+      const listing=await result(db.from('lp_listings').select('*').eq('id',listingId).single());
+      const check=validateAuctionEligibility(listing,edition);
+      if(!check.eligible)throw Error(check.reason);
+      const sortOrder=Number.isInteger(body.sort_order)?body.sort_order:0;
+      await result(db.from('lp_auction_edition_items').insert({edition_id:edition.id,listing_id:listing.id,sort_order:sortOrder}));
+      return ok({success:true,edition_id:edition.id,listing_id:listing.id},201);
+    }
+    if(subAction==='remove-item'){
+      const listingId=extractIdFromSlug(body.listing_id||body.listingId||'');
+      if(!listingId||!uuid(listingId))throw Error('Identificador de anuncio no válido.');
+      await result(db.from('lp_auction_edition_items').delete().eq('edition_id',id).eq('listing_id',listingId));
+      return ok({success:true,removed:true});
+    }
+    if(subAction==='status'){
+      const status=body.status;
+      if(!['draft','published','cancelled'].includes(status))throw Error('Estado de edición no válido.');
+      const updated=await result(db.from('lp_auction_editions').update({status,updated_at:new Date().toISOString()}).eq('id',id).select('*').single());
+      return ok(updated);
+    }
+    return ok({error:'Acción de edición no encontrada'},404);
+  }
  if(action==='profile'){const alias=publicAlias(body.alias);return ok(await rpc('lp_update_profile',{p_actor:user.id,p_alias:alias,p_show_purchases:body.showPurchases===true}))}
  if(action==='review'&&uuid(id||'')){const score=Number(body.score);if(!Number.isInteger(score)||score<1||score>5)throw Error('Elige una puntuación entre 1 y 5 estrellas.');const comment=body.comment?noContact(text(body.comment,0,500)):'';return ok(await rpc('lp_create_review',{p_order:id,p_actor:user.id,p_score:score,p_comment:comment}),201)}
  if(action==='publish'){const title=noContact(text(body.title,5,100)),description=noContact(text(body.description,30,4000)),location=noContact(text(body.location,2,80));if(!categories.includes(body.category)||!conditions.includes(body.condition)||!['sale','auction'].includes(body.mode)||!['pickup','shipping'].includes(body.delivery))throw Error('Revisa la categoría, el estado y el tipo de venta.');if(!Array.isArray(body.images)||body.images.length<1||body.images.length>6||body.images.some((url:unknown)=>typeof url!=='string'||!url.startsWith(process.env.NEXT_PUBLIC_SUPABASE_URL+'/storage/v1/object/public/product-images/v2/'+user.id+'/')))throw Error('Sube entre una y seis fotos del artículo.');const end=body.mode==='auction'?new Date(body.ends_at):null;if(end&&(!Number.isFinite(end.getTime())||end.getTime()<Date.now()+3600000||end.getTime()>Date.now()+30*86400000))throw Error('La subasta debe durar entre una hora y treinta días.');const price=cents(body.price),buyNow=body.mode==='auction'&&body.buy_now?cents(body.buy_now):null;if(buyNow&&buyNow<=price)throw Error('Comprar ahora debe superar el precio de salida.');const shipping=body.delivery==='shipping'?Math.round(Number(body.shipping||0)*100):0;if(!Number.isInteger(shipping)||shipping<0||shipping>10000)throw Error('Revisa los gastos de envío.');const recent=await db.from('lp_listings').select('id',{head:true,count:'exact'}).eq('seller_id',user.id).gte('created_at',new Date(Date.now()-3600000).toISOString());if((recent.count||0)>=20)return ok({error:'Has alcanzado el límite de publicaciones por hora.'},429);const l=await result(db.from('lp_listings').insert({seller_id:user.id,environment:environment(),title,description,location,category:body.category,condition:body.condition,mode:body.mode,delivery:body.delivery,images:body.images,price_cents:price,buy_now_cents:buyNow,shipping_cents:shipping,ends_at:end?.toISOString()||null}).select('id').single());return ok(l,201)}

--- a/src/lib/__tests__/featured-auctions.test.ts
+++ b/src/lib/__tests__/featured-auctions.test.ts
@@ -1,0 +1,176 @@
+import {
+  getEditionTemporalStatus,
+  formatCountdown,
+  validateAuctionEligibility,
+  isOperatorUser,
+} from '../featured-auctions';
+
+describe('LP-FEAT-019: Subastas destacadas y coordinadas', () => {
+  describe('Cálculo de estados temporales de la edición', () => {
+    const startsAt = '2026-09-15T10:00:00.000Z';
+    const referenceEndsAt = '2026-09-20T20:00:00.000Z';
+
+    it('devuelve "upcoming" (Próximamente) antes del inicio', () => {
+      const before = new Date('2026-09-14T10:00:00.000Z');
+      expect(getEditionTemporalStatus(startsAt, referenceEndsAt, before)).toBe('upcoming');
+    });
+
+    it('devuelve "active" (En curso) durante la ventana editorial', () => {
+      const during = new Date('2026-09-16T12:00:00.000Z');
+      expect(getEditionTemporalStatus(startsAt, referenceEndsAt, during)).toBe('active');
+    });
+
+    it('devuelve "ended" (Finalizada) tras el cierre de referencia', () => {
+      const after = new Date('2026-09-20T20:00:01.000Z');
+      expect(getEditionTemporalStatus(startsAt, referenceEndsAt, after)).toBe('ended');
+    });
+
+    it('AC-04: una ampliación anti-sniping en un artículo no altera el estado de la edición', () => {
+      // El artículo se extiende 2 minutos más allá del cierre de referencia de la edición
+      const extendedArticleEndsAt = '2026-09-20T20:02:00.000Z';
+      const now = new Date('2026-09-20T20:00:30.000Z');
+
+      // La edición ya concluyó su ventana informativa
+      expect(getEditionTemporalStatus(startsAt, referenceEndsAt, now)).toBe('ended');
+      // El artículo sigue vivo de forma independiente
+      expect(new Date(extendedArticleEndsAt).getTime() > now.getTime()).toBe(true);
+    });
+  });
+
+  describe('Formato accesible de cuenta atrás (RNF-03)', () => {
+    it('formatea días y horas', () => {
+      const now = new Date('2026-09-10T10:00:00.000Z');
+      const target = new Date('2026-09-12T14:30:00.000Z');
+      expect(formatCountdown(target, now)).toBe('2 días y 4 horas');
+    });
+
+    it('formatea horas y minutos', () => {
+      const now = new Date('2026-09-10T10:00:00.000Z');
+      const target = new Date('2026-09-10T13:45:00.000Z');
+      expect(formatCountdown(target, now)).toBe('3 horas y 45 min');
+    });
+
+    it('muestra "Finalizada" si el tiempo ha expirado', () => {
+      const now = new Date('2026-09-10T10:00:00.000Z');
+      const target = new Date('2026-09-10T09:59:00.000Z');
+      expect(formatCountdown(target, now)).toBe('Finalizada');
+    });
+  });
+
+  describe('Criterios de elegibilidad (AC-01, RN-01)', () => {
+    const baseEdition = {
+      environment: 'sandbox',
+      starts_at: '2026-09-15T10:00:00.000Z',
+      reference_ends_at: '2026-09-20T20:00:00.000Z',
+    };
+    const now = new Date('2026-09-12T10:00:00.000Z');
+
+    it('rechaza artículos que no son modalidad subasta (compra directa / precio cerrado)', () => {
+      const listing = {
+        mode: 'sale',
+        status: 'available',
+        environment: 'sandbox',
+        ends_at: null,
+      };
+      const res = validateAuctionEligibility(listing, baseEdition, now);
+      expect(res.eligible).toBe(false);
+      expect(res.reason).toContain('Solo se pueden asociar artículos en modalidad de subasta');
+    });
+
+    it('rechaza artículos no disponibles (vendidos, reservados o retirados)', () => {
+      const listing = {
+        mode: 'auction',
+        status: 'sold',
+        environment: 'sandbox',
+        ends_at: '2026-09-20T20:00:00.000Z',
+      };
+      const res = validateAuctionEligibility(listing, baseEdition, now);
+      expect(res.eligible).toBe(false);
+      expect(res.reason).toContain('El artículo debe estar disponible');
+    });
+
+    it('rechaza artículos de un entorno distinto (sandbox vs live)', () => {
+      const listing = {
+        mode: 'auction',
+        status: 'available',
+        environment: 'live',
+        ends_at: '2026-09-20T20:00:00.000Z',
+      };
+      const res = validateAuctionEligibility(listing, baseEdition, now);
+      expect(res.eligible).toBe(false);
+      expect(res.reason).toContain('El artículo no pertenece al mismo entorno de la edición');
+    });
+
+    it('rechaza subastas que ya han finalizado', () => {
+      const listing = {
+        mode: 'auction',
+        status: 'available',
+        environment: 'sandbox',
+        ends_at: '2026-09-11T20:00:00.000Z', // En el pasado
+      };
+      const res = validateAuctionEligibility(listing, baseEdition, now);
+      expect(res.eligible).toBe(false);
+      expect(res.reason).toContain('No se pueden asociar subastas ya finalizadas');
+    });
+
+    it('acepta subastas válidas y elegibles', () => {
+      const listing = {
+        mode: 'auction',
+        status: 'available',
+        environment: 'sandbox',
+        ends_at: '2026-09-20T19:00:00.000Z',
+      };
+      const res = validateAuctionEligibility(listing, baseEdition, now);
+      expect(res.eligible).toBe(true);
+    });
+  });
+
+  describe('Autorización operativa (RNF-01, AC-06)', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = {...originalEnv};
+    });
+
+    afterAll(() => {
+      process.env = originalEnv;
+    });
+
+    it('rechaza usuarios anónimos o no identificados', async () => {
+      expect(await isOperatorUser(null)).toBe(false);
+      expect(await isOperatorUser(undefined)).toBe(false);
+    });
+
+    it('autoriza por variable de entorno OPERATOR_EMAILS', async () => {
+      process.env.OPERATOR_EMAILS = 'operaciones@lapela.es,admin@lapela.es';
+      expect(await isOperatorUser({id: 'u1', email: 'operaciones@lapela.es'})).toBe(true);
+      expect(await isOperatorUser({id: 'u2', email: 'usuario@example.com'})).toBe(false);
+    });
+
+    it('autoriza por tabla de operadores si está configurado en bd', async () => {
+      const mockDb = {
+        from: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({data: {user_id: 'op-123'}}),
+            }),
+          }),
+        }),
+      };
+      expect(await isOperatorUser({id: 'op-123', email: 'otro@example.com'}, mockDb)).toBe(true);
+    });
+
+    it('rechaza usuarios corrientes sin rol operativo', async () => {
+      const mockDb = {
+        from: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({data: null}),
+            }),
+          }),
+        }),
+      };
+      expect(await isOperatorUser({id: 'user-regular', email: 'vendedor@example.com'}, mockDb)).toBe(false);
+    });
+  });
+});

--- a/src/lib/featured-auctions.ts
+++ b/src/lib/featured-auctions.ts
@@ -1,0 +1,130 @@
+export type TemporalStatus = 'upcoming' | 'active' | 'ended';
+
+/**
+ * Calcula el estado temporal de una edición editorial según la ventana horaria.
+ * - 'upcoming': antes de starts_at (próximamente)
+ * - 'active': entre starts_at y reference_ends_at (en curso)
+ * - 'ended': tras reference_ends_at (finalizada)
+ */
+export function getEditionTemporalStatus(
+  startsAt: string | Date,
+  referenceEndsAt: string | Date,
+  now: Date = new Date()
+): TemporalStatus {
+  const starts = new Date(startsAt).getTime();
+  const ends = new Date(referenceEndsAt).getTime();
+  const current = now.getTime();
+
+  if (current < starts) return 'upcoming';
+  if (current >= ends) return 'ended';
+  return 'active';
+}
+
+/**
+ * Genera una representación textual y accesible del tiempo restante hasta una fecha objetivo.
+ * RNF-03: Alternativa textual accesible sin depender exclusivamente de animaciones.
+ */
+export function formatCountdown(targetDate: string | Date, now: Date = new Date()): string {
+  const diffMs = new Date(targetDate).getTime() - now.getTime();
+  if (diffMs <= 0) return 'Finalizada';
+
+  const totalSeconds = Math.floor(diffMs / 1000);
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const totalHours = Math.floor(totalMinutes / 60);
+  const days = Math.floor(totalHours / 24);
+  const hours = totalHours % 24;
+  const minutes = totalMinutes % 60;
+
+  if (days > 0) {
+    return `${days} ${days === 1 ? 'día' : 'días'}${hours > 0 ? ` y ${hours} ${hours === 1 ? 'hora' : 'horas'}` : ''}`;
+  }
+  if (hours > 0) {
+    return `${hours} ${hours === 1 ? 'hora' : 'horas'}${minutes > 0 ? ` y ${minutes} min` : ''}`;
+  }
+  if (minutes > 0) {
+    return `${minutes} ${minutes === 1 ? 'minuto' : 'minutos'}`;
+  }
+  return 'Menos de 1 minuto';
+}
+
+/**
+ * Criterios de elegibilidad (AC-01, RN-01):
+ * - Modalidad subasta
+ * - Disponible
+ * - Mismo entorno (sandbox/live)
+ * - Subasta activa (ends_at en el futuro)
+ */
+export function validateAuctionEligibility(
+  listing: {
+    mode?: string;
+    status?: string;
+    environment?: string;
+    ends_at?: string | null;
+  } | null | undefined,
+  edition: {
+    environment?: string;
+    reference_ends_at?: string;
+    starts_at?: string;
+  },
+  now: Date = new Date()
+): { eligible: boolean; reason?: string } {
+  if (!listing) {
+    return { eligible: false, reason: 'El artículo no existe.' };
+  }
+  if (listing.mode !== 'auction') {
+    return { eligible: false, reason: 'Solo se pueden asociar artículos en modalidad de subasta.' };
+  }
+  if (listing.status !== 'available') {
+    return { eligible: false, reason: 'El artículo debe estar disponible.' };
+  }
+  if (edition.environment && listing.environment !== edition.environment) {
+    return { eligible: false, reason: 'El artículo no pertenece al mismo entorno de la edición.' };
+  }
+  if (!listing.ends_at || new Date(listing.ends_at).getTime() <= now.getTime()) {
+    return { eligible: false, reason: 'No se pueden asociar subastas ya finalizadas.' };
+  }
+
+  return { eligible: true };
+}
+
+/**
+ * Verifica si el usuario actual tiene permisos de operación para gestionar ediciones.
+ * RNF-01, AC-06: Verificación de rol operativo explícito.
+ */
+export async function isOperatorUser(
+  user: { id: string; email?: string | null } | null | undefined,
+  db?: any
+): Promise<boolean> {
+  if (!user) return false;
+
+  const configuredEmails = (process.env.OPERATOR_EMAILS || '')
+    .split(',')
+    .map(e => e.trim().toLowerCase())
+    .filter(Boolean);
+  if (user.email && configuredEmails.includes(user.email.toLowerCase())) {
+    return true;
+  }
+
+  const configuredIds = (process.env.OPERATOR_USER_IDS || '')
+    .split(',')
+    .map(id => id.trim())
+    .filter(Boolean);
+  if (configuredIds.includes(user.id)) {
+    return true;
+  }
+
+  if (db && typeof db.from === 'function') {
+    try {
+      const { data } = await db
+        .from('lp_operators')
+        .select('user_id')
+        .eq('user_id', user.id)
+        .maybeSingle();
+      if (data) return true;
+    } catch {
+      // Si la tabla no está disponible o falla, depende de variables de entorno
+    }
+  }
+
+  return false;
+}

--- a/src/models/marketplace.ts
+++ b/src/models/marketplace.ts
@@ -1,15 +1,114 @@
 import {createClient} from '@supabase/supabase-js';
 import {productSlug, extractIdFromSlug} from '@/lib/slugs';
+import {getEditionTemporalStatus} from '@/lib/featured-auctions';
+import type {AuctionEdition} from '@/types';
 
 export type PublicProfile={alias:string};
 
 export function admin(){return createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!,process.env.SUPABASE_SERVICE_ROLE_KEY!,{auth:{persistSession:false,autoRefreshToken:false}})}
 export const publicFields='id,seller_id,title,description,category,condition,location,images,mode,price_cents,buy_now_cents,shipping_cents,delivery,ends_at,status,bid_count,created_at';
 export function fallbackProfile(id:string):PublicProfile{return {alias:`usuario-${id.replace(/-/g,'').slice(0,12)}`}}
-export function card(l:any,profile?:PublicProfile){const seller=profile||fallbackProfile(l.seller_id||l.id);return {id:l.id,slug:productSlug(l.id,l.title),name:l.title,description:l.description,price:l.price_cents/100,type:l.mode,image:l.images[0],detailImage:l.images[0],location:l.location,category:l.category,status:l.status,seller:seller.alias,sellerProfile:seller,buyer:null,bid_count:l.bid_count,auction_ends_at:l.ends_at,updated_at:l.created_at,time:l.created_at}}
+export function card(l:any,profile?:PublicProfile,featuredEdition?:any){const seller=profile||fallbackProfile(l.seller_id||l.id);return {id:l.id,slug:productSlug(l.id,l.title),name:l.title,description:l.description,price:l.price_cents/100,type:l.mode,image:l.images[0],detailImage:l.images[0],location:l.location,category:l.category,status:l.status,seller:seller.alias,sellerProfile:seller,buyer:null,bid_count:l.bid_count,auction_ends_at:l.ends_at,updated_at:l.created_at,time:l.created_at,featuredEdition:featuredEdition||l.featuredEdition||undefined}}
 export async function profilesById(db:any,ids:string[]){const unique=[...new Set(ids.filter(Boolean))];if(!unique.length)return new Map<string,PublicProfile>();const {data,error}=await db.from('lp_profiles').select('id,alias').in('id',unique);if(error)throw Error('No se han podido cargar los perfiles.');const profiles=new Map<string,PublicProfile>((data||[]).map((p:any)=>[p.id,{alias:p.alias}]));for(const id of unique)if(!profiles.has(id))profiles.set(id,fallbackProfile(id));return profiles}
 export async function rpc(name:string,args:Record<string,unknown>={}){const {data,error}=await admin().rpc(name,args);if(error)throw Error(error.message);return data}
 
-export async function getListingByIdOrSlug(idOrSlug:string){const id=extractIdFromSlug(idOrSlug);if(!id)return null;const env=process.env.LAPELA_PAYMENTS_MODE==='simulated'?'sandbox':'live';const db=admin();const {data,error}=await db.from('lp_listings').select('*').eq('id',id).maybeSingle();if(error||!data||data.environment!==env)return null;const {data:bids,error:bidsError}=await db.from('lp_bids').select('id,bidder_id,amount_cents,created_at').eq('listing_id',id).order('created_at',{ascending:false}).limit(50);if(bidsError)return null;const profiles=await profilesById(db,[data.seller_id,...(bids||[]).map((b:any)=>b.bidder_id)]);const {seller_id,highest_bidder,...safe}=data;return {...safe,seller:profiles.get(seller_id),bids:(bids||[]).map(({bidder_id,...b}:any)=>({...b,bidder:profiles.get(bidder_id)})),slug:productSlug(data.id,data.title)}}
+export async function getCurrentFeaturedEdition(dbClient?:any,targetEnv?:string):Promise<AuctionEdition|null>{
+  const env=targetEnv||(process.env.LAPELA_PAYMENTS_MODE==='simulated'?'sandbox':'live');
+  const db=dbClient||admin();
+  const {data:editions,error}=await db.from('lp_auction_editions').select('*').eq('environment',env).eq('status','published').order('starts_at',{ascending:true});
+  if(error||!editions||!editions.length)return null;
+  const now=new Date();
+  const active=editions.find((e:any)=>{
+    const s=new Date(e.starts_at).getTime(),r=new Date(e.reference_ends_at).getTime(),n=now.getTime();
+    return n>=s&&n<r;
+  });
+  const upcoming=editions.find((e:any)=>new Date(e.starts_at).getTime()>now.getTime());
+  const chosen=active||upcoming;
+  if(!chosen)return null;
+
+  const {data:items,error:itemsError}=await db.from('lp_auction_edition_items').select(`sort_order,listing:lp_listings(${publicFields})`).eq('edition_id',chosen.id).order('sort_order',{ascending:true});
+  if(itemsError||!items)return null;
+
+  const valid=items.filter((it:any)=>it.listing&&it.listing.status==='available'&&it.listing.mode==='auction');
+  if(!valid.length)return null;
+
+  const profiles=await profilesById(db,valid.map((it:any)=>it.listing.seller_id));
+  const temporalStatus=getEditionTemporalStatus(chosen.starts_at,chosen.reference_ends_at,now);
+  const editionMeta={id:chosen.id,slug:chosen.slug,title:chosen.title,status:chosen.status,temporal_status:temporalStatus};
+
+  const products=valid.map((it:any)=>({
+    ...card(it.listing,profiles.get(it.listing.seller_id),editionMeta),
+    featuredEdition:editionMeta
+  }));
+
+  return {
+    id:chosen.id,
+    slug:chosen.slug,
+    title:chosen.title,
+    description:chosen.description,
+    environment:chosen.environment,
+    starts_at:chosen.starts_at,
+    reference_ends_at:chosen.reference_ends_at,
+    status:chosen.status,
+    temporal_status:temporalStatus,
+    image_url:chosen.image_url,
+    items_count:products.length,
+    items:products
+  };
+}
+
+export async function getAuctionEditionBySlug(slugOrId:string,dbClient?:any,targetEnv?:string):Promise<AuctionEdition|null>{
+  const env=targetEnv||(process.env.LAPELA_PAYMENTS_MODE==='simulated'?'sandbox':'live');
+  const db=dbClient||admin();
+  let query=db.from('lp_auction_editions').select('*').eq('environment',env);
+  if(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(slugOrId)){
+    query=query.or(`id.eq.${slugOrId},slug.eq.${slugOrId}`);
+  }else{
+    query=query.eq('slug',slugOrId);
+  }
+  const {data:edition,error}=await query.maybeSingle();
+  if(error||!edition)return null;
+
+  const now=new Date();
+  const temporalStatus=getEditionTemporalStatus(edition.starts_at,edition.reference_ends_at,now);
+  const {data:items,error:itemsError}=await db.from('lp_auction_edition_items').select(`sort_order,listing:lp_listings(${publicFields})`).eq('edition_id',edition.id).order('sort_order',{ascending:true});
+  if(itemsError)return null;
+
+  const validListings=(items||[]).map((it:any)=>it.listing).filter(Boolean);
+  const profiles=await profilesById(db,validListings.map((l:any)=>l.seller_id));
+  const editionMeta={id:edition.id,slug:edition.slug,title:edition.title,status:edition.status,temporal_status:temporalStatus};
+
+  const products=validListings.map((l:any)=>({
+    ...card(l,profiles.get(l.seller_id),editionMeta),
+    featuredEdition:editionMeta
+  }));
+
+  return {
+    id:edition.id,
+    slug:edition.slug,
+    title:edition.title,
+    description:edition.description,
+    environment:edition.environment,
+    starts_at:edition.starts_at,
+    reference_ends_at:edition.reference_ends_at,
+    status:edition.status,
+    temporal_status:temporalStatus,
+    image_url:edition.image_url,
+    items_count:products.length,
+    items:products
+  };
+}
+
+export async function getListingByIdOrSlug(idOrSlug:string){const id=extractIdFromSlug(idOrSlug);if(!id)return null;const env=process.env.LAPELA_PAYMENTS_MODE==='simulated'?'sandbox':'live';const db=admin();const {data,error}=await db.from('lp_listings').select('*').eq('id',id).maybeSingle();if(error||!data||data.environment!==env)return null;const {data:bids,error:bidsError}=await db.from('lp_bids').select('id,bidder_id,amount_cents,created_at').eq('listing_id',id).order('created_at',{ascending:false}).limit(50);if(bidsError)return null;const profiles=await profilesById(db,[data.seller_id,...(bids||[]).map((b:any)=>b.bidder_id)]);const {seller_id,highest_bidder,...safe}=data;
+  let featuredEdition=undefined;
+  try{
+    const {data:itemLink}=await db.from('lp_auction_edition_items').select('edition:lp_auction_editions(id,slug,title,status,starts_at,reference_ends_at)').eq('listing_id',data.id).maybeSingle();
+    if(itemLink?.edition&&(itemLink.edition as any).status==='published'){
+      const ed=itemLink.edition as any;
+      featuredEdition={id:ed.id,slug:ed.slug,title:ed.title,status:ed.status,temporal_status:getEditionTemporalStatus(ed.starts_at,ed.reference_ends_at)};
+    }
+  }catch{}
+  return {...safe,seller:profiles.get(seller_id),bids:(bids||[]).map(({bidder_id,...b}:any)=>({...b,bidder:profiles.get(bidder_id)})),slug:productSlug(data.id,data.title),featuredEdition}}
 
 export async function getPublicProfile(alias:string){const db=admin();const normalized=alias.trim().toLowerCase();const {data:profile,error}=await db.from('lp_profiles').select('id,alias,show_purchases,created_at').eq('alias',normalized).maybeSingle();if(error||!profile)return null;const env=process.env.LAPELA_PAYMENTS_MODE==='simulated'?'sandbox':'live';const [activeResult,salesResult,reviewsResult,purchasesResult]=await Promise.all([db.from('lp_listings').select(publicFields).eq('seller_id',profile.id).eq('status','available').eq('environment',env).order('created_at',{ascending:false}).limit(24),db.from('lp_orders').select('id',{head:true,count:'exact'}).eq('seller_id',profile.id).eq('status','completed'),db.from('lp_reviews').select('id,author_id,score,comment,created_at').eq('recipient_id',profile.id).order('created_at',{ascending:false}).limit(30),profile.show_purchases?db.from('lp_orders').select('id,listing:lp_listings(id,seller_id,title,description,category,location,images,mode,price_cents,ends_at,status,bid_count,created_at)').eq('buyer_id',profile.id).eq('status','completed').order('created_at',{ascending:false}).limit(24):Promise.resolve({data:[]})]);if(activeResult.error||salesResult.error||reviewsResult.error||(purchasesResult as any).error)throw Error('No se ha podido cargar el perfil.');const reviews=reviewsResult.data||[];const purchases=(purchasesResult as any).data||[];const ids=[...reviews.map((r:any)=>r.author_id),...purchases.map((o:any)=>o.listing?.seller_id).filter(Boolean),profile.id];const profiles=await profilesById(db,ids);const scoreCount=reviews.length;const averageScore=scoreCount?Math.round((reviews.reduce((sum:number,r:any)=>sum+r.score,0)/scoreCount)*10)/10:null;return {profile:{alias:profile.alias,memberSince:profile.created_at,showPurchases:profile.show_purchases},stats:{completedSales:salesResult.count||0,averageScore,reviewCount:scoreCount},activeListings:(activeResult.data||[]).map((l:any)=>card(l,profiles.get(profile.id))),purchases:profile.show_purchases?purchases.filter((o:any)=>o.listing).map((o:any)=>card(o.listing,profiles.get(o.listing.seller_id))):[],reviews:reviews.map((r:any)=>({id:r.id,score:r.score,comment:r.comment,created_at:r.created_at,author:profiles.get(r.author_id)}))}}
+

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,6 +23,13 @@ export interface Product {
   category?: string;
   auction_ends_at?: string; // ISO 8601 string
   slug?: string;
+  featuredEdition?: {
+    id: string;
+    slug: string;
+    title: string;
+    status?: string;
+    temporal_status?: 'upcoming' | 'active' | 'ended';
+  };
 }
 
 export interface Profile {
@@ -72,3 +79,28 @@ export interface Bid {
     username: string;
   };
 }
+
+export interface AuctionEdition {
+  id: string;
+  slug: string;
+  title: string;
+  description: string;
+  environment?: 'sandbox' | 'live';
+  starts_at: string;
+  reference_ends_at: string;
+  status: 'draft' | 'published' | 'cancelled';
+  temporal_status: 'upcoming' | 'active' | 'ended';
+  image_url?: string | null;
+  items_count?: number;
+  items?: Product[];
+}
+
+export interface AuctionEditionItem {
+  id: string;
+  edition_id: string;
+  listing_id: string;
+  sort_order: number;
+  created_at: string;
+  product?: Product;
+}
+

--- a/supabase/migrations/202609120001_featured_auctions.sql
+++ b/supabase/migrations/202609120001_featured_auctions.sql
@@ -1,0 +1,50 @@
+-- LP-FEAT-019: Subastas destacadas y coordinadas (La Subasta de la Pela)
+begin;
+
+-- Personal autorizado de operación
+create table if not exists public.lp_operators (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  role text not null default 'operator' check(role in ('operator', 'admin')),
+  created_at timestamptz not null default now()
+);
+
+-- Edición editorial con ventana y cierre de referencia
+create table if not exists public.lp_auction_editions (
+  id uuid primary key default gen_random_uuid(),
+  slug text not null unique check(slug ~ '^[a-z0-9][a-z0-9_-]{2,80}$'),
+  title text not null check(length(trim(title)) between 3 and 120),
+  description text not null default '' check(length(trim(description)) <= 1000),
+  environment text not null default 'sandbox' check(environment in ('sandbox', 'live')),
+  starts_at timestamptz not null,
+  reference_ends_at timestamptz not null,
+  status text not null default 'draft' check(status in ('draft', 'published', 'cancelled')),
+  image_url text,
+  created_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  check (reference_ends_at > starts_at)
+);
+
+-- Asociación de subastas a una edición (una subasta solo puede pertenecer a una edición a la vez)
+create table if not exists public.lp_auction_edition_items (
+  id uuid primary key default gen_random_uuid(),
+  edition_id uuid not null references public.lp_auction_editions(id) on delete cascade,
+  listing_id uuid not null references public.lp_listings(id) on delete cascade,
+  sort_order integer not null default 0,
+  created_at timestamptz not null default now(),
+  unique(edition_id, listing_id),
+  unique(listing_id)
+);
+
+create index if not exists lp_auction_editions_env_status on public.lp_auction_editions(environment, status, starts_at);
+create index if not exists lp_auction_edition_items_edition on public.lp_auction_edition_items(edition_id, sort_order);
+create index if not exists lp_auction_edition_items_listing on public.lp_auction_edition_items(listing_id);
+
+alter table public.lp_operators enable row level security;
+alter table public.lp_auction_editions enable row level security;
+alter table public.lp_auction_edition_items enable row level security;
+
+revoke all on public.lp_operators, public.lp_auction_editions, public.lp_auction_edition_items from anon, authenticated;
+grant all on public.lp_operators, public.lp_auction_editions, public.lp_auction_edition_items to service_role;
+
+commit;


### PR DESCRIPTION
## Alcance

Implementa la funcionalidad de subastas destacadas y coordinadas ("La Subasta de la Pela") con selección editorial, ventana concentrada, cuenta atrás informativa, distintivos en tarjetas y fichas de producto, y página de edición dedicada con resultados sin acciones de puja para artículos cerrados.

## Trazabilidad

- Spec: `specs/LP-FEAT-019-subastas-destacadas.md`
- Issue: Closes #48
- Rama: `codex/lp-feat-019-subastas-destacadas`

## Cambios realizados

- **Base de datos:** Migración `supabase/migrations/202609120001_featured_auctions.sql` (`lp_operators`, `lp_auction_editions`, `lp_auction_edition_items`).
- **Dominio:** `src/lib/featured-auctions.ts` con cálculo de estados temporales (`upcoming`, `active`, `ended`), validación de elegibilidad (`AC-01`), formato accesible de cuenta atrás (`RNF-03`) y verificación de rol de operador (`AC-06`).
- **Modelos:** `src/models/marketplace.ts` con consultas sin N+1 (`getCurrentFeaturedEdition`, `getAuctionEditionBySlug`) y asociación de edición en `getListingByIdOrSlug`.
- **API:** Endpoints públicos `GET /api/market/featured-edition` y `GET /api/market/auction-edition/:slug`, y de gestión operativa protegida `POST /api/market/auction-edition`.
- **Frontend:**
  - Componente `FeaturedAuctionSection` en portada y `/subastas` (`AC-02`).
  - Distintivo en `ProductCard` y `ProductDetailInteractive` con enlace a la edición (`RF-03`).
  - Página dedicada `/subastas/ediciones/[slug]` con metadatos SEO y visualización de resultados en ediciones concluidas sin opciones de puja en anuncios cerrados (`RF-05`, `AC-05`).
  - Estilos integrados en `src/app/globals.css` respetando la paleta de la peseta.

## Validación

- `npm test src/lib/__tests__/ src/components/__tests__/FeaturedAuctionSection.test.tsx src/components/__tests__/ProductCard.test.tsx src/components/__tests__/ProductDetailInteractive.test.tsx`: 11 suites pasadas, 72 pruebas exitosas.
- `npm run specs:check`: 27 fichas y 38 documentos validados sin errores.
- `npm run build`: Compilación de producción completada con código 0, incorporando la ruta dinámica `/subastas/ediciones/[slug]`.

## Contexto transversal

`PROJECT_CONTEXT.md` actualizado en la sección 4 (Subastas) para documentar la capacidad de subastas destacadas y coordinadas.